### PR TITLE
[XPTI] Fix undefined behaviour in hash_t::bit_count()

### DIFF
--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -142,8 +142,8 @@ struct hash_t {
   ///
   /// This function computes the bit count using integer arithmetic. For zero,
   /// it returns 1 to ensure zero fields keep their place in the hash. For
-  /// non-zero values, it counts the number of shifts needed to reduce the value
-  /// to zero, which is equivalent to the position of the highest set bit plus 1.
+  /// non-zero values, it counts the number of shifts needed to reduce the
+  /// value to zero, i.e. the position of the highest set bit plus 1.
   ///
   /// @param value A 64-bit integer for which the bit count is to be calculated.
   /// @return The number of bits required to represent the input value.

--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -140,10 +140,10 @@ inline bool is_valid_uid(const xpti::uid128_t &UID) {
 struct hash_t {
   /// @brief Calculates the number of bits required to represent a given value.
   ///
-  /// This function uses the logarithm base 2 (log2) of the input value to
-  /// calculate the number of bits required to represent it. It then adds 1 to
-  /// the result to account for the fact that log2 of a value is one less than
-  /// the number of bits required to represent it.
+  /// This function computes the bit count using integer arithmetic. For zero,
+  /// it returns 1 to ensure zero fields keep their place in the hash. For
+  /// non-zero values, it counts the number of shifts needed to reduce the value
+  /// to zero, which is equivalent to the position of the highest set bit plus 1.
   ///
   /// @param value A 64-bit integer for which the bit count is to be calculated.
   /// @return The number of bits required to represent the input value.

--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -148,13 +148,19 @@ struct hash_t {
   /// @param value A 64-bit integer for which the bit count is to be calculated.
   /// @return The number of bits required to represent the input value.
   unsigned bit_count(uint64_t value) {
-    // FIXME: using std::log2 is imprecise. There is no guarantee that the
-    // implementation has actual integer overload for log2 and it is allowed to
-    // do a static_cast<double>(value) to compute the result. Not every integer
-    // is represetntable as floating-point, meaning that byte representation of
-    // value as double may not be the same as for integer, resulting in
-    // different result.
-    return static_cast<unsigned>(std::log2(value)) + 1;
+    // Computed with integer arithmetic: std::log2 is imprecise for large
+    // integers, which are not all representable as floating-point, and
+    // std::log2(0) is -inf, which is not representable as unsigned.
+    // Zero still takes one bit, so that a zero field keeps its place in the
+    // hash instead of letting the neighbouring fields shift into it.
+    if (value == 0)
+      return 1;
+    unsigned count = 0;
+    while (value) {
+      ++count;
+      value >>= 1;
+    }
+    return count;
   }
 
   /// @brief Compacts the file ID, function ID, line number, and column number


### PR DESCRIPTION
## Problem

`xpti::hash_t::bit_count()` computed the number of bits needed to represent a value as:

```cpp
return static_cast<unsigned>(std::log2(value)) + 1;
```

This has two defects, both flagged by UndefinedBehaviorSanitizer:

1. **`value == 0` is undefined behaviour.** `std::log2(0)` is `-inf`, and converting `-inf` to `unsigned` is UB. On x86-64 the conversion yields `0x80000000`, so the function returned `0x80000001`, which is then used as a *shift count* in `compact()`/`compact_short()` — UB a second time. A zero `line` or `column` is the common case, not a corner case: `sycl/include/sycl/detail/code_location.hpp` defaults both to 0, so this fires on ordinary tracing paths.

2. **Imprecision for large values.** The FIXME above the function already documented it: not every `uint64_t` is representable as `double`, so `log2` can round up and the result is one too large. Measured against an exact integer implementation, every value from `2^49-1` upward is off by one (e.g. `2^49-1`: 50 vs the correct 49; `UINT64_MAX`: 65 vs 64).

UBSan diagnostic (build configured with `-DLLVM_USE_SANITIZER=Address;Undefined`; the runtime is built with `-fno-sanitize-recover=all`, so this aborts the process):

```
include/xpti/xpti_data_types.h:157:34: runtime error: -inf is outside the range of
representable values of type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

It reproduced in 46 SYCL unit tests — any test that emits a tracepoint with an unknown line/column.

## Fix

Replace the floating-point computation with an integer loop, and keep the historical "a zero field still occupies one bit" behaviour so the packing in `compact()`/`compact_short()` does not change shape:

```cpp
if (value == 0)
  return 1;
unsigned count = 0;
while (value) {
  ++count;
  value >>= 1;
}
return count;
```

Returning 1 for 0 matters: with 0 the neighbouring fields would shift into the zero field's place, and `(file=1,func=1,line=0,col=1)` and `(file=1,func=1,line=1,col=0)` would collide. Over a small sampled domain, that variant raised the number of colliding pairs from 4016 to 6339, so it is kept at 1.

## Impact on hash values

Values change only where the old code was UB or imprecise:

| input | old | new |
|---|---|---|
| `0` | `0x80000001` (UB) | `1` |
| `1 .. 2^48` | same | same |
| `2^49-1 .. UINT64_MAX` | one too large | exact |

The only live consumer is `compact_short()` -> `combine_short()` -> `std::hash<xpti::uid128_t>`, used as the bucket hash for two `phmap` maps in `xptifw/src/xpti_trace_framework.cpp`, each guarded by an exact `std::equal_to<uid128_t>`; a changed hash costs probes, never correctness. The visible 64-bit `uid64` is not derived from this function (`xpti_trace_framework.cpp` sets it from the tracepoint pointer). `compact()` and `combine()` have no callers. No test pins a concrete hash or universal ID: the `xptiUniversalID*` tests in `xptifw/unit_test/xpti_correctness_tests.cpp` use the unrelated `uid_t::hash()` and assert relationally, the literal assertions in `xpti_api_tests.cpp` are commented out, and the `sycl/test-e2e/XPTI` FileCheck patterns capture IDs as regexes.

## Verification

- `ninja check-sycl` in an ASan+UBSan build: 3516 passed, 0 failed (the 46 tests that aborted on this diagnostic now pass).
- `XptiTraceTests-Non_Preview_Tests`: 23/23.
- Note: `XPTI_ENABLE_TESTS` is forced `OFF` by `unified-runtime/CMakeLists.txt`, so the standalone XPTI gtest binaries do not exist in this configuration and could not be run.

## Notes

`#include <cmath>` at the top of the header is now unused, but it is left in place to avoid changing what this widely-included header pulls in transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
