### PR TITLE
[clang] Fix out-of-bounds read when filtering dependency-file entries

### DIFF
--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -287,7 +287,7 @@ bool DependencyFileGenerator::sawDependency(StringRef Filename, bool FromModule,
 
   // Remove dependencies that are prefixed by the Filter string.
   for (const std::string &FD : DependencyFilter)
-    if (FD.compare(0, FD.size(), Filename.data(), FD.size()) == 0)
+    if (Filename.starts_with(FD))
       return false;
 
   if (IncludeSystemHeaders)


### PR DESCRIPTION
## Problem

`DependencyFileGenerator::sawDependency()` filters out dependencies whose name starts with a filter string:

```cpp
// Remove dependencies that are prefixed by the Filter string.
for (const std::string &FD : DependencyFilter)
  if (FD.compare(0, FD.size(), Filename.data(), FD.size()) == 0)
    return false;
```

`Filename` is a `StringRef`, and `std::string::compare(pos, len, const char *s, size_t n)` reads `n` bytes from `s` unconditionally. When the filename is shorter than the filter, this reads past the end of the referenced buffer. `StringRef` is not guaranteed to be NUL-terminated, and here it points into memory owned by a `BumpPtrAllocator`, so the read runs into the allocator's redzone.

AddressSanitizer report, hit while compiling `sycl/test/include_deps/header_reach.cpp` with `-fsycl`:

```
ERROR: AddressSanitizer: use-after-poison on address ...
READ of size 42 at ... thread T0
    #0 ... in clang::DependencyFileGenerator::sawDependency(llvm::StringRef, bool, bool, bool, bool)
       clang/lib/Frontend/DependencyFile.cpp:290
```

The regression came from `536d89fbf022` / `c18aa4ba8ecb`, where the argument was changed from `Filename` to `Filename.data()` to make the `compare` overload resolve — which silently changed a bounded comparison into an unbounded read.

## Fix

Use the operation the comment describes:

```cpp
for (const std::string &FD : DependencyFilter)
  if (Filename.starts_with(FD))
    return false;
```

`StringRef::starts_with` performs the same prefix test, is bounds-safe (a filename shorter than the filter simply does not match), and needs no length arithmetic. Behaviour is identical for every input that was previously well-defined.

## Verification

`sycl/test/include_deps/header_reach.cpp` passes with ASan enabled; `ninja check-sycl` in the ASan+UBSan build reports 3516 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
