### PR TITLE
[SYCL] Make Command::isHostTask() virtual instead of downcasting on MType

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -241,12 +241,6 @@ std::vector<ur_event_handle_t> Command::getUrEvents(events_range Events) const {
   return getUrEvents(Events, MWorkerQueue.get(), isHostTask());
 }
 
-bool Command::isHostTask() const {
-  return (MType == CommandType::RUN_CG) /* host task has this type also */ &&
-         ((static_cast<const ExecCGCommand *>(this))->getCG().getType() ==
-          CGType::CodeplayHostTask);
-}
-
 namespace {
 
 struct EnqueueNativeCommandData {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -251,7 +251,10 @@ public:
                                                     queue_impl *CommandQueue,
                                                     bool IsHostTaskCommand);
 
-  bool isHostTask() const;
+  /// Returns true iff this command represents a host task. Only ExecCGCommand
+  /// can, so the base implementation always returns false: the command type
+  /// alone does not imply the dynamic type of the command.
+  virtual bool isHostTask() const { return false; }
 
 protected:
   std::shared_ptr<queue_impl> MQueue;
@@ -648,6 +651,10 @@ public:
   std::string_view getTypeString() const;
 
   detail::CG &getCG() const { return *MCommandGroup; }
+
+  bool isHostTask() const final {
+    return getCG().getType() == CGType::CodeplayHostTask;
+  }
 
   // MEmptyCmd is only employed if this command refers to host-task.
   // The mechanism of lookup for single EmptyCommand amongst users of


### PR DESCRIPTION
## Problem

`Command::isHostTask()` deduced the dynamic type of the command from its type tag and then downcast unconditionally:

```cpp
bool Command::isHostTask() const {
  return (MType == CommandType::RUN_CG) /* host task has this type also */ &&
         ((static_cast<const ExecCGCommand *>(this))->getCG().getType() ==
          CGType::CodeplayHostTask);
}
```

`static_cast` to a derived type is undefined behaviour unless the object really is of that type; nothing in the type system enforces `RUN_CG => ExecCGCommand`, only convention. When the object is a plain `Command` subobject, `getCG()` reads `MCommandGroup` from beyond the end of the allocation.

AddressSanitizer report (ASan+UBSan build, `SchedulerTest.DontEnqueueDepsIfOneOfThemIsBlocked`):

```
ERROR: AddressSanitizer: global-buffer-overflow on address ...
READ of size 4 at ... thread T0
    #0 ... in getType sycl/source/detail/cg.hpp:104
    #1 ... in sycl::_V1::detail::Command::isHostTask() const
       sycl/source/detail/scheduler/commands.cpp:246
    #2 ... in isBlocking sycl/source/detail/scheduler/commands.hpp:178
    #3 ... in Scheduler::GraphProcessor::handleBlockingCmd(...)
```

In the shipping runtime the invariant does hold today — `ExecCGCommand` is the only class constructed with `RUN_CG` — so this is a latent UB rather than a known miscompile. It is not merely theoretical, though: 10 unit tests trip it through `MockCommand`, which is a direct `Command` subclass that defaults to `RUN_CG` (`sycl/unittests/scheduler/SchedulerTestUtils.hpp`, `LeavesCollection.cpp`, `buffer/BufferReleaseBase.hpp`), and any future non-`ExecCGCommand` command with that tag would reintroduce it silently.

## Fix

Let the command answer the question, so the type tag is no longer load-bearing:

```cpp
// Command
/// Returns true iff this command represents a host task. Only ExecCGCommand
/// can, so the base implementation always returns false: the command type
/// alone does not imply the dynamic type of the command.
virtual bool isHostTask() const { return false; }

// ExecCGCommand
bool isHostTask() const final {
  return getCG().getType() == CGType::CodeplayHostTask;
}
```

and drop the out-of-line definition in `commands.cpp`.

## Why this is safe

- **Semantically identical in production.** `ExecCGCommand` is the only class ever constructed with `RUN_CG` (`commands.cpp`), and the other ten `Command` subclasses use different tags, so the `MType` test was redundant rather than restrictive.
- **No virtual dispatch during construction or destruction.** The three call sites — `isBlocking()` (reached from `GraphProcessor`), `getUrEvents()`, and the `CGType::BarrierWaitlist` path in `ExecCGCommand::enqueueImp()` — all run on fully constructed objects. `~Command()` only calls `MEvent->cleanDepEventsThroughOneLevel()`.
- **`getCG()` is always valid where the override can run.** `MCommandGroup` is set in the `ExecCGCommand` constructor's init list and is never `reset()` or `release()`d anywhere in `sycl/source`.
- **No ABI impact.** `Command` already has a vtable (it has a virtual destructor), so `sizeof` is unchanged; only a slot is added. `Command`/`ExecCGCommand` live in `sycl/source/detail/scheduler/`, are not installed headers, and appear in no ABI dump — `check-sycl` ABI tests pass (21 passed, 1 unsupported).
- `final` on the override is safe: nothing derives from `ExecCGCommand`.

## Verification

- `SchedulerTests-Non_Preview_Tests`: 67/67, no ASan report (the 10 previously failing tests included).
- `ninja check-sycl` in the ASan+UBSan build: 3516 passed, 0 failed.
- ABI tests: `llvm-lit tools/sycl/test/abi` -> 21 passed, 1 unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
