### PR TITLE
[SYCL] Don't skip memory-record removal when buffer write-back throws

### DIFF
--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -143,8 +143,15 @@ void SYCLMemObjT::updateHostMemory(void *const Ptr) {
 void SYCLMemObjT::updateHostMemory() {
   // Don't try updating host memory when shutting down.
   if ((MUploadDataFunctor != nullptr) && MNeedWriteBack &&
-      GlobalHandler::instance().isOkToDefer())
-    MUploadDataFunctor();
+      GlobalHandler::instance().isOkToDefer()) {
+    // A failing write-back is reported as an asynchronous exception by
+    // Scheduler::addCopyBack and must not skip the removal of the memory
+    // record below, otherwise the record and the commands it owns are leaked.
+    try {
+      MUploadDataFunctor();
+    } catch (...) {
+    }
+  }
 
   // If we're attached to a memory record, process the deletion of the memory
   // record. We may get detached before we do this.


### PR DESCRIPTION
## Problem

`SYCLMemObjT::updateHostMemory()` performs the write-back and then detaches the memory object from the scheduler:

```cpp
void SYCLMemObjT::updateHostMemory() {
  if ((MUploadDataFunctor != nullptr) && MNeedWriteBack &&
      GlobalHandler::instance().isOkToDefer())
    MUploadDataFunctor();          // <-- can throw

  if (MRecord) {
    bool Result = Scheduler::getInstance().removeMemoryObject(...);
    ...
  }
  releaseHostMem(MShadowCopy);
  ...
}
```

`MUploadDataFunctor()` ends up in `Scheduler::addCopyBack()` followed by `Event->wait()`, and a failing copy-back throws from `GraphProcessor::waitForEvent()`. The exception then propagates out of `updateHostMemory()`, so **`removeMemoryObject()`, `releaseHostMem()` and the interop `urMemRelease()` below it are all skipped**. Both callers (`~buffer_impl` and `~image_impl`) wrap the call in `try { ... } catch (...) {}`, so the failure is silently discarded and the object is destroyed with its scheduler record still attached.

The leaked set is the whole `MemObjRecord`: its alloca/release/copy-back/exec commands, the `LeavesCollection`, and — because `Command::MQueue` is a `shared_ptr<queue_impl>` — the queue and its context with the kernel/program caches. LeakSanitizer reported 41 allocations / ~10.7 KB for a single occurrence (`SchedulerTest.FailedCopyBackException`), all of them *indirect* leaks with no direct leak, which is the signature of an orphaned graph rather than a forgotten `delete`.

Confirmed with a `catch throw` breakpoint: the throw originates at `sycl_mem_obj_t.cpp:140` (`Event->wait()`) and is caught only by `~buffer_impl`'s `catch (...)` in `buffer_impl.hpp`.

This is reachable from ordinary API use — `queue::submit` with a buffer whose copy-back fails at the UR level — not just from tests.

## Fix

Contain the failure so the teardown below always runs:

```cpp
if ((MUploadDataFunctor != nullptr) && MNeedWriteBack &&
    GlobalHandler::instance().isOkToDefer()) {
  // A failing write-back is reported as an asynchronous exception by
  // Scheduler::addCopyBack and must not skip the removal of the memory
  // record below, otherwise the record and the commands it owns are leaked.
  try {
    MUploadDataFunctor();
  } catch (...) {
  }
}
```

Observable behaviour is unchanged: both existing callers already discarded this exception, and the failure is still reported to the user through the asynchronous exception `Scheduler::addCopyBack()` records.

## Verification

- `SchedulerTest.FailedCopyBackException`: no leak report, test passes.
- `SchedulerTests-Non_Preview_Tests`: 67/67 over 5 consecutive runs, no ASan/LSan output.
- `ninja check-sycl` in the ASan+UBSan build: 3516 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
