### PR TITLE
[SYCL] Release commands that fail to enqueue asynchronously

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -414,14 +414,16 @@ public:
     AsyncCodeLocationPtr.reset();
 #endif
 
+    // NotifyHostTaskCompletion() may destroy MThisCmd, so query anything we
+    // still need from it up front.
+    auto QueuePtr = MThisCmd->MEvent->getSubmittedQueue();
     try {
       // If we enqueue blocked users - ur level could throw exception that
       // should be treated as async now.
       Scheduler::getInstance().NotifyHostTaskCompletion(MThisCmd);
     } catch (...) {
-      auto CurrentException = std::current_exception();
-      auto QueuePtr = MThisCmd->MEvent->getSubmittedQueue();
-      Scheduler::getInstance().reportAsyncException(QueuePtr, CurrentException);
+      Scheduler::getInstance().reportAsyncException(QueuePtr,
+                                                    std::current_exception());
     }
   }
 };

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1161,8 +1161,12 @@ void Scheduler::GraphBuilder::cleanupCommand(
   if (SYCLConfig<SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::get())
     return;
 
+  // A command whose enqueue failed will never be retried, so it is as ready for
+  // deletion as a successfully enqueued one.
   assert(Cmd->MLeafCounter == 0 &&
-         (Cmd->isSuccessfullyEnqueued() || AllowUnsubmitted));
+         (Cmd->isSuccessfullyEnqueued() ||
+          Cmd->MEnqueueStatus == EnqueueResultT::SyclEnqueueFailed ||
+          AllowUnsubmitted));
   Command::CommandType CmdT = Cmd->getType();
 
   assert(CmdT != Command::ALLOCA && CmdT != Command::ALLOCA_SUB_BUF);

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -422,11 +422,25 @@ void Scheduler::enqueueUnblockedCommands(events_range ToEnqueue,
     if (!Cmd)
       continue;
     EnqueueResultT Res;
-    bool Enqueued =
-        GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
-    if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw exception(make_error_code(errc::runtime),
-                      "Enqueue process failed.");
+    try {
+      bool Enqueued = GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res,
+                                                     ToCleanUp, Cmd);
+      if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
+    } catch (...) {
+      // enqueueCommand() and the throw above may leave the command permanently
+      // unenqueued - unlike a synchronous submission, nothing will ever retry
+      // it. Schedule it for deletion the same way enqueueCommandForCG() does,
+      // otherwise it keeps its queue, and everything the queue owns, alive
+      // forever through the shared_ptr in Command::MQueue.
+      if (Cmd->MEnqueueStatus == EnqueueResultT::SyclEnqueueFailed &&
+          Cmd->MLeafCounter == 0 && !Cmd->MMarkedForCleanup) {
+        Cmd->MMarkedForCleanup = true;
+        ToCleanUp.push_back(Cmd);
+      }
+      throw;
+    }
   }
 }
 
@@ -498,6 +512,7 @@ void Scheduler::NotifyHostTaskCompletion(Command *Cmd) {
   auto CmdEvent = Cmd->getEvent();
   auto QueueImpl = CmdEvent->getSubmittedQueue();
   assert(QueueImpl && "Submitted queue for host task must not be null");
+  std::exception_ptr EnqueueException;
   {
     ReadLockT Lock = acquireReadLock();
 
@@ -512,11 +527,21 @@ void Scheduler::NotifyHostTaskCompletion(Command *Cmd) {
       // update self-event status
       CmdEvent->setComplete();
     }
-    Scheduler::enqueueUnblockedCommands(Cmd->MBlockedUsers, Lock, ToCleanUp);
+    try {
+      Scheduler::enqueueUnblockedCommands(Cmd->MBlockedUsers, Lock, ToCleanUp);
+    } catch (...) {
+      // The failure is reported to the async handler by the caller, but the
+      // bookkeeping below must still happen or the commands collected in
+      // ToCleanUp (this host task included) are leaked.
+      EnqueueException = std::current_exception();
+    }
   }
   QueueImpl->revisitUnenqueuedCommandsState(CmdEvent);
 
   cleanupCommands(ToCleanUp);
+
+  if (EnqueueException)
+    std::rethrow_exception(EnqueueException);
 }
 
 void Scheduler::deferMemObjRelease(const std::shared_ptr<SYCLMemObjI> &MemObj) {
@@ -714,9 +739,11 @@ void Scheduler::reportAsyncException(
     const std::shared_ptr<queue_impl> &QueuePtr,
     const std::exception_ptr &ExceptionPtr) {
   std::lock_guard<std::mutex> Lock(MAsyncExceptionsMutex);
-  MAsyncExceptions[AsyncExceptionKey{QueuePtr,
-                                     QueuePtr->getContextImplWeakPtr()}]
-      .PushBack(ExceptionPtr);
+  AsyncExceptionEntry &Entry = MAsyncExceptions[AsyncExceptionKey{
+      QueuePtr, QueuePtr->getContextImplWeakPtr()}];
+  if (!Entry.Handler)
+    Entry.Handler = QueuePtr->getAsynchHandler();
+  Entry.Exceptions.PushBack(ExceptionPtr);
 }
 
 void Scheduler::flushAsyncExceptions() {
@@ -726,14 +753,15 @@ void Scheduler::flushAsyncExceptions() {
     std::swap(AsyncExceptions, MAsyncExceptions);
   }
   for (auto &ExceptionsEntryIt : AsyncExceptions) {
-    exception_list Exceptions = std::move(ExceptionsEntryIt.second);
+    exception_list Exceptions = std::move(ExceptionsEntryIt.second.Exceptions);
 
     if (Exceptions.size() == 0)
       continue;
 
-    std::shared_ptr<queue_impl> Queue = ExceptionsEntryIt.first.first.lock();
-    if (Queue && Queue->getAsynchHandler()) {
-      Queue->getAsynchHandler()(std::move(Exceptions));
+    // Use the submitting queue's handler even if the queue itself is already
+    // gone - it is the handler the user registered for these exceptions.
+    if (const async_handler &Handler = ExceptionsEntryIt.second.Handler) {
+      Handler(std::move(Exceptions));
       continue;
     }
 

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -898,7 +898,13 @@ protected:
                                                             RHS.second);
     }
   };
-  std::map<AsyncExceptionKey, exception_list, AsyncExceptionKeyOwnerLess>
+  struct AsyncExceptionEntry {
+    exception_list Exceptions;
+    // The handler of the submitting queue, remembered here because the queue
+    // may be destroyed before the exceptions are flushed.
+    async_handler Handler;
+  };
+  std::map<AsyncExceptionKey, AsyncExceptionEntry, AsyncExceptionKeyOwnerLess>
       MAsyncExceptions;
 
   friend class Command;


### PR DESCRIPTION
## Problem

Two related defects on the asynchronous (host-task completion) enqueue path.

### 1. A command whose asynchronous enqueue fails is never released

`Scheduler::NotifyHostTaskCompletion()` unblocks the users of a completed host task and then does the bookkeeping:

```cpp
{
  ReadLockT Lock = acquireReadLock();
  ...
  Scheduler::enqueueUnblockedCommands(Cmd->MBlockedUsers, Lock, ToCleanUp);
}
QueueImpl->revisitUnenqueuedCommandsState(CmdEvent);
cleanupCommands(ToCleanUp);
```

`enqueueUnblockedCommands()` reaches `enqueueImpKernel()`, which **throws** on failure. The exception propagates out of `NotifyHostTaskCompletion()`, so neither `revisitUnenqueuedCommandsState()` nor `cleanupCommands(ToCleanUp)` runs — and `ToCleanUp` already contains the completed host-task command at that point. Nothing ever retries the failed command, so it is never deleted, and since `Command::MQueue` is a `shared_ptr<queue_impl>`, the queue, its default context and the attached kernel/program caches stay alive for the rest of the process.

The synchronous path already handles exactly this: `Scheduler::enqueueCommandForCG()` wraps the same failure in `try`/`catch` with a `CleanUp()` lambda whose comment reads *"destroy required resources to avoid memory leak"*. The asynchronous path has no equivalent, which is why `QueueApiFailures.QueueSingleTask`, `QueueHostTaskFail` and `QueueParallelFor` (synchronous failures) are leak-free while `QueueApiFailures.QueueKernelAsync` leaks.

LeakSanitizer reports 32-40 allocations, all *indirect* with no direct leak — the signature of an unreachable object graph rather than a forgotten `delete`: `queue_impl`, the platform default `context_impl` and its `KernelProgramCache`, both `ExecCGCommand`s, their `CG`s and `event_impl`s.

Note that the existing `SyclEnqueueFailed` check in `enqueueUnblockedCommands()` is dead code for this path: `enqueueImpKernel()` throws rather than returning a status, so the failure never reaches the `Res.MResult` test. The fix has to be a `catch`.

### 2. The asynchronous exception is lost once the queue dies

`Scheduler::reportAsyncException()` keys the pending exception list on a `weak_ptr` to the queue, and `flushAsyncExceptions()` re-locks it to find the handler:

```cpp
std::shared_ptr<queue_impl> Queue = ExceptionsEntryIt.first.first.lock();
if (Queue && Queue->getAsynchHandler()) { ... }
```

Once (1) is fixed, the queue is genuinely destroyed, `lock()` fails, and the exception falls through to `defaultAsyncHandler()`, which calls `std::terminate()`. This aborted the test binary deterministically (5/5 runs) — the leak had been masking it, because a queue that never dies always locks successfully.

## Fix

- `Scheduler::enqueueUnblockedCommands()`: wrap the enqueue in `try`/`catch`; on failure mark the command and push it onto `ToCleanUp` — guarded by `MEnqueueStatus == SyclEnqueueFailed && MLeafCounter == 0 && !MMarkedForCleanup` — then rethrow. The command is then deleted by the existing `cleanupCommands()` path, under the graph *write* lock, which already relinks `MDeps`/`MUsers` and respects `MDeferredCleanupCommands`.
- `Scheduler::NotifyHostTaskCompletion()`: catch, still run `revisitUnenqueuedCommandsState()` and `cleanupCommands()`, then `std::rethrow_exception()` so the caller still reports it to the async handler.
- `GraphBuilder::cleanupCommand()`: accept a command whose enqueue failed. It will never be retried, so it is as ready for deletion as a successfully enqueued one; without this the new `ToCleanUp` entry trips the existing assertion.
- `commands.cpp`: hoist `MThisCmd->MEvent->getSubmittedQueue()` above the `NotifyHostTaskCompletion()` call. The command is now freed by the cleanup before the rethrow, so reading it in the `catch` was a use-after-free — ASan caught this while developing the fix, it is not hypothetical.
- `Scheduler::reportAsyncException()`/`flushAsyncExceptions()`: store the submitting queue's `async_handler` alongside the exception list and use it at flush time. It is the handler the user registered for those exceptions, so this is also the behaviour the spec expects; `defaultAsyncHandler()` remains the fallback when no handler was registered.

## Scope / deliberately not fixed

- If a *dependency* of a blocked command throws, the blocked command stays `SyclEnqueueReady` and is still leaked. Deleting a never-attempted command needs `AllowUnsubmitted` plumbed through `ToCleanUp`; it is a different case from the one reported here.
- Commands with a non-zero `MLeafCounter` are not deleted, because `cleanupCommand()` does not remove entries from `LeavesCollection` and deleting one would corrupt the record. This is the same restriction the synchronous path has.

## Verification

- `QueueApiFailures.QueueKernelAsync`: no leak report, test passes.
- `XptiTraceTests-Non_Preview_Tests` and `-Preview_Tests`: 23/23 each, exit 0, no ASan/LSan/UBSan output; 8/8 consecutive runs (the path is threaded, so it was stressed).
- `SchedulerTests-Non_Preview_Tests` 67/67, `BufferTests` 34/34, `QueueTests` 28/28 — all clean.
- `ninja check-sycl` in the ASan+UBSan build: 3516 passed, 0 failed.
- Mutation check: replacing the new cleanup condition with `if (false && ...)` brings the leak straight back (32 allocations), so the verification is not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
