### PR TITLE
[UR][mock] Tie command-buffer command handles to their command buffer

### DIFF
--- a/unified-runtime/scripts/templates/mockddi.cpp.mako
+++ b/unified-runtime/scripts/templates/mockddi.cpp.mako
@@ -152,6 +152,13 @@ namespace driver
                         mock::releaseDummyHandle(${item['name']});
                     %elif item['retain']:
                         mock::retainDummyHandle(${item['name']});
+                    ## Command handles have no release entry point: the command
+                    ## buffer owns them, so tie their lifetime to it.
+                    %elif 'type' in item and item['type'] == 'ur_exp_command_buffer_command_handle_t' and re.search(r"CommandBufferAppend.*Exp$", fname):
+                        // optional output handle
+                        if(${item['name']}) {
+                            *${item['name']} = mock::createDummyChildHandle<${item['type']}>(hCommandBuffer);
+                        }
                     %elif 'type' in item:
                         %if 'range' in item or ('optional' in item and item['optional']):
                         // optional output handle

--- a/unified-runtime/source/adapters/mock/ur_mockddi.cpp
+++ b/unified-runtime/source/adapters/mock/ur_mockddi.cpp
@@ -10977,7 +10977,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11095,7 +11096,8 @@ urCommandBufferAppendKernelLaunchWithArgsExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11185,7 +11187,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11278,7 +11281,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11374,7 +11378,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11467,7 +11472,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11560,7 +11566,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11668,7 +11675,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11779,7 +11787,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11889,7 +11898,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -11985,7 +11995,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -12075,7 +12086,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }
@@ -12165,7 +12177,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     // optional output handle
     if (phCommand) {
       *phCommand =
-          mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
+          mock::createDummyChildHandle<ur_exp_command_buffer_command_handle_t>(
+              hCommandBuffer);
     }
     result = UR_RESULT_SUCCESS;
   }

--- a/unified-runtime/source/mock/ur_mock_helpers.hpp
+++ b/unified-runtime/source/mock/ur_mock_helpers.hpp
@@ -33,10 +33,14 @@ struct dummy_handle_t_ {
       : MStorage(DataSize), MData(MStorage.data()), MSize(DataSize) {}
   dummy_handle_t_(unsigned char *Data, size_t Size)
       : MData(Data), MSize(Size) {}
+  ~dummy_handle_t_();
+
   std::atomic<size_t> MRefCounter = 1;
   std::vector<unsigned char> MStorage;
   unsigned char *MData = nullptr;
   size_t MSize;
+  // Handles whose lifetime is tied to this one, see createDummyChildHandle.
+  std::vector<dummy_handle_t_ *> MChildren;
 
   template <typename T> T getDataAs() {
     assert(MStorage.size() >= sizeof(T));
@@ -57,6 +61,16 @@ using dummy_handle_t = dummy_handle_t_ *;
 template <class T> inline T createDummyHandle(size_t Size = 0) {
   dummy_handle_t DummyHandlePtr = new dummy_handle_t_(Size);
   return reinterpret_cast<T>(DummyHandlePtr);
+}
+
+// Allocates a dummy handle of type T which is owned by the handle 'Parent':
+// it is deallocated together with the parent. Used for handles that have no
+// release entry point in UR, e.g. the command handles returned by
+// urCommandBufferAppend*Exp, which the command buffer owns.
+template <class T> inline T createDummyChildHandle(void *Parent) {
+  dummy_handle_t ChildPtr = new dummy_handle_t_();
+  reinterpret_cast<dummy_handle_t>(Parent)->MChildren.push_back(ChildPtr);
+  return reinterpret_cast<T>(ChildPtr);
 }
 
 // Allocates a dummy handle of type T with support of reference counting
@@ -81,6 +95,11 @@ template <class T> inline void releaseDummyHandle(T Handle) {
 template <class T> inline void retainDummyHandle(T Handle) {
   auto DummyHandlePtr = reinterpret_cast<dummy_handle_t>(Handle);
   ++DummyHandlePtr->MRefCounter;
+}
+
+inline dummy_handle_t_::~dummy_handle_t_() {
+  for (dummy_handle_t Child : MChildren)
+    releaseDummyHandle(Child);
 }
 
 struct callbacks_t {


### PR DESCRIPTION
## Problem

The generated mock adapter creates a dummy handle for any optional output handle parameter:

```cpp
// optional output handle
if (phCommand) {
  *phCommand = mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>();
}
```

`ur_exp_command_buffer_command_handle_t` has no retain/release entry point in `ur_api.h`: its lifetime is tied to the command buffer that produced it. So the contract documented on `createDummyHandle` — *"The handle has to be deallocated using 'releaseDummyHandle'"* — cannot be satisfied by anyone, and each of the 13 `urCommandBufferAppend*Exp` entry points leaks one handle per appended command.

LeakSanitizer report from a SYCL graph unit test (ASan+UBSan build):

```
Direct leak of 192 byte(s) in 4 object(s) allocated from:
    #0 ... in mock::createDummyHandle<ur_exp_command_buffer_command_handle_t>
       unified-runtime/source/mock/ur_mock_helpers.hpp:58
    #1 ... in driver::urCommandBufferAppendKernelLaunchWithArgsExp(...)
    #2 ... in urCommandBufferAppendKernelLaunchWithArgsExp
    #3 ... in sycl::_V1::detail::enqueueImpCommandBufferKernel(...)
    #4 ... in exec_graph_impl::enqueueNodeDirect(...)
    #5 ... in exec_graph_impl::createCommandBuffers(...)
```

It accounted for 16 failing tests in `CommandGraphExtensionTests` (`WholeGraphUpdateTest.*`, `CommandGraphTest.CheckFinalizeBehavior`, `UpdatableException`, ...).

## Fix

Model the actual ownership. `dummy_handle_t_` gains a list of child handles that it releases in its destructor, plus a helper to create a handle owned by a parent:

```cpp
// Allocates a dummy handle of type T which is owned by the handle 'Parent':
// it is deallocated together with the parent. Used for handles that have no
// release entry point in UR, e.g. the command handles returned by
// urCommandBufferAppend*Exp, which the command buffer owns.
template <class T> inline T createDummyChildHandle(void *Parent);
```

The 13 append entry points now use `createDummyChildHandle<...>(hCommandBuffer)`, so `urCommandBufferReleaseExp` frees the command handles with the buffer. `scripts/templates/mockddi.cpp.mako` gets the matching special case, so regenerating `ur_mockddi.cpp` reproduces the change (verified: the guard selects exactly those 13 sites — `urCommandBufferAppendNativeCommandExp` has no `phCommand` output — and `hCommandBuffer` is the parameter name in all of them).

## Why this is safe

- **No use-after-free.** In the SYCL runtime the command handles (`exec_graph_impl::MCommandMap`) and the command buffers (`partition::MCommandBuffers`) are siblings owned by the same `exec_graph_impl` and released together in `~exec_graph_impl()`, after the last read of `MCommandMap`. The graph update path always runs through a live `exec_graph_impl`.
- **No early free.** `urCommandBufferRetainExp` has no call sites in `sycl/`, so a command buffer's refcount goes 1 -> 0 exactly once; a 1 -> 2 -> 1 sequence cannot drop the children early.
- The child list is bounded by the node count of one `finalize()`; nothing appends to a finalized buffer.

## Verification

- `CommandGraphExtensionTests-Non_Preview_Tests`: 118 passed, zero ASan/LSan output (was 16 leaking tests).
- `ninja check-sycl` in the ASan+UBSan build: 3516 passed, 0 failed.

## Note

`createDummyChildHandle` reinterpret_casts its `Parent` argument, which is safe for the generated call sites because the default `urCommandBufferCreateExp` mock returns a real dummy handle. A test that replace-overrides command-buffer creation with an arbitrary pointer while leaving the append entry points at their default would corrupt memory — the same assumption the existing `EnqueueMemBufferMap` mock already makes about `hBuffer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
