### PR TITLE
[SYCL] Fix out-of-bounds accesses in unit test device-image helpers

### DIFF
--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -105,8 +105,9 @@ ur_result_t redefinedUrProgramCreate(void *pParams) {
 
 ur_result_t redefinedUrProgramCreateWithBinary(void *pParams) {
   auto params = *static_cast<ur_program_create_with_binary_params_t *>(pParams);
-  for (uint32_t i = 0; i < *params.pnumDevices; ++i)
-    redefinedUrProgramCreateCommon(*params.pppBinaries[i]);
+  // All numDevices entries of ppBinaries point to the same image, so only the
+  // first one needs to be tracked.
+  redefinedUrProgramCreateCommon(**params.pppBinaries);
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -378,11 +378,10 @@ inline MockProperty makeSpecConstant(std::vector<char> &ValData,
                                      std::initializer_list<uint32_t> IDs,
                                      std::initializer_list<uint32_t> Offsets,
                                      std::tuple<T...> DefaultValues) {
-  const size_t PropByteArraySize = sizeof...(T) * sizeof(uint32_t) * 3;
+  const uint64_t PropByteArraySize = sizeof...(T) * sizeof(uint32_t) * 3;
   std::vector<char> DescData;
   DescData.resize(8 + PropByteArraySize);
-  std::uninitialized_copy(&PropByteArraySize, &PropByteArraySize + 8,
-                          DescData.data());
+  std::memcpy(DescData.data(), &PropByteArraySize, sizeof(PropByteArraySize));
 
   if (ValData.empty())
     ValData.resize(8); // Reserve first 8 bytes for array size.
@@ -397,8 +396,7 @@ inline MockProperty makeSpecConstant(std::vector<char> &ValData,
                                            decltype(DefaultValues)>::type));
     // Update raw data array size
     uint64_t NewValSize = ValData.size();
-    std::uninitialized_copy(&NewValSize, &NewValSize + sizeof(uint64_t),
-                            ValData.data());
+    std::memcpy(ValData.data(), &NewValSize, sizeof(NewValSize));
   }
 
   auto FillData = [PrevOffset = 0, PrevSize, &ValData, &IDs, &Offsets,
@@ -516,10 +514,10 @@ inline MockProperty makeAspectsProp(const std::vector<sycl::aspect> &Aspects) {
   std::vector<char> ValData(BYTES_FOR_SIZE +
                             Aspects.size() * sizeof(sycl::aspect));
   uint64_t ValDataSize = ValData.size();
-  std::uninitialized_copy(&ValDataSize, &ValDataSize + sizeof(uint64_t),
-                          ValData.data());
+  std::memcpy(ValData.data(), &ValDataSize, sizeof(ValDataSize));
   auto *AspectsPtr = reinterpret_cast<const unsigned char *>(&Aspects[0]);
-  std::uninitialized_copy(AspectsPtr, AspectsPtr + Aspects.size(),
+  std::uninitialized_copy(AspectsPtr,
+                          AspectsPtr + Aspects.size() * sizeof(sycl::aspect),
                           ValData.data() + BYTES_FOR_SIZE);
   return {"aspects", ValData, SYCL_PROPERTY_TYPE_BYTE_ARRAY};
 }
@@ -528,8 +526,7 @@ inline MockProperty makeReqdWGSizeProp(const std::vector<int> &ReqdWGSize) {
   const size_t BYTES_FOR_SIZE = 8;
   std::vector<char> ValData(BYTES_FOR_SIZE + ReqdWGSize.size() * sizeof(int));
   uint64_t ValDataSize = ValData.size();
-  std::uninitialized_copy(&ValDataSize, &ValDataSize + sizeof(uint64_t),
-                          ValData.data());
+  std::memcpy(ValData.data(), &ValDataSize, sizeof(ValDataSize));
   auto *ReqdWGSizePtr = reinterpret_cast<const unsigned char *>(&ReqdWGSize[0]);
   std::uninitialized_copy(ReqdWGSizePtr,
                           ReqdWGSizePtr + ReqdWGSize.size() * sizeof(int),


### PR DESCRIPTION
## Problem

### 1. `sycl/unittests/helpers/MockDeviceImage.hpp` — 8 objects instead of 8 bytes

Four places wrote a size header like this:

```cpp
std::uninitialized_copy(&PropByteArraySize, &PropByteArraySize + 8,
                        DescData.begin());
```

The intent is "copy 8 bytes", but the operands are `size_t *`, so the range spans 8 *objects* = 64 bytes: an out-of-bounds read of the scalar, and a 64-byte write into a 20-byte `DescData`.

UBSan diagnostic (the read; the build uses `-fno-sanitize-recover=all`, so it aborts):

```
/usr/include/c++/13/bits/stl_algobase.h:388:20: runtime error: load of address ...
with insufficient space for an object of type 'const unsigned long'
```

Because these helpers run from **static initializers** (`MockDeviceImageArray` globals), the process died before `main()`, so `--gtest_list_tests` printed nothing and lit reported the whole binary as `failed_to_discover_tests_from_gtest` — 6 test failures (`SYCL2020Tests`, `DynamicLinkingTests`, `KernelAndProgramTests`, each in Preview and Non-Preview) with no indication of the real cause.

Fixed by using `std::memcpy` with `sizeof`, and by making `PropByteArraySize` a `uint64_t` to match the on-disk property format.

The same file had a latent under-copy in `makeAspectsProp()`:

```cpp
std::uninitialized_copy(AspectsPtr, AspectsPtr + Aspects.size(), ...);
```

`AspectsPtr` is `const unsigned char *`, so this copies `Aspects.size()` *bytes* instead of `Aspects.size() * sizeof(sycl::aspect)`. Not a sanitizer error (in bounds both ways) and currently harmless because both callers pass a single small-valued aspect, but a multi-aspect test would silently read zeros past the first aspect. The neighbouring `makeReqdWGSizeProp()` already multiplies by `sizeof(int)`; this now matches it.

### 2. `sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp` — indexing the wrong pointer

```cpp
for (unsigned i = 0; i < *params.pnumDevices; ++i)
  ... *params.pppBinaries[i] ...
```

`*params.pppBinaries[i]` parses as `*(params.pppBinaries[i])`: it indexes the pointer *to the argument* inside the params struct, not the binaries array, so for `i > 0` it reads past the struct.

```
ERROR: AddressSanitizer: stack-buffer-overflow
    ... in redefinedUrProgramCreateWithBinary
```

`ProgramManager::createURProgram` fills every entry of that array with the same image pointer, so tracking one entry is both correct and what the code accidentally did before; the loop is dropped in favour of `**params.pppBinaries`. Indexing correctly instead would double-count images in the two-device case and break `verifyImageUse`.

## Verification

```
llvm-lit -sv --filter "SYCL2020Tests|DynamicLinkingTests|KernelAndProgramTests" tools/sycl/test/Unit
Total Discovered Tests: 140
  Passed: 140 (100.00%)
```

All six binaries run to completion with `UBSAN_OPTIONS=print_stacktrace=1` and exit 0 with no sanitizer output (previously they aborted before listing their tests). Full `ninja check-sycl` in an ASan+UBSan build: 3516 passed, 0 failed — and the discovered-test count rose from 2352 to 2626 once these binaries could enumerate again.

Note: verified as part of a larger set of sanitizer fixes, not in isolation on top of pristine `sycl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
