### PR TITLE
[SYCL] Fix leaks in SYCL unit tests

### DIFF
--- a/sycl/unittests/Extensions/BindlessImages/ImageDescriptors.cpp
+++ b/sycl/unittests/Extensions/BindlessImages/ImageDescriptors.cpp
@@ -84,10 +84,11 @@ TEST(BindlessImagesExtensionTests, ImageDescriptorPropagatesLayout) {
 
   try {
     auto ImgHandle = syclexp::map_external_image_memory(MemHandle, Desc, Q);
-    (void)ImgHandle;
+    syclexp::unmap_external_image_memory(ImgHandle, Desc.type, Q);
   } catch (const sycl::exception &e) {
     FAIL() << "Caught unexpected SYCL exception: " << e.what();
   }
+  syclexp::release_external_memory(MemHandle, Q);
 
   EXPECT_EQ(MapExternalArrayCallCounter, 1);
 }
@@ -220,10 +221,11 @@ TEST(BindlessImagesExtensionTests, ImageDescriptorPropagatesSlicePitch) {
 
   try {
     auto ImgHandle = syclexp::map_external_image_memory(MemHandle, Desc, Q);
-    (void)ImgHandle;
+    syclexp::unmap_external_image_memory(ImgHandle, Desc.type, Q);
   } catch (const sycl::exception &e) {
     FAIL() << "Caught unexpected SYCL exception: " << e.what();
   }
+  syclexp::release_external_memory(MemHandle, Q);
 
   EXPECT_EQ(MapExternalArrayCallCounter, 1);
 }

--- a/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/InOrderQueue.cpp
@@ -444,6 +444,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   auto InOrderGraphExec = InOrderGraph.finalize();
   auto EventGraph = InOrderQueue.submit(
       [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
+
+  sycl::free(TestData, InOrderQueue);
 }
 
 TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
@@ -504,6 +506,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
   auto InOrderGraphExec = InOrderGraph.finalize();
   auto EventGraph = InOrderQueue.submit(
       [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
+
+  sycl::free(TestData, InOrderQueue);
 }
 
 // Validate that enqueuing a graph with

--- a/sycl/unittests/Extensions/CommandGraph/Queries.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Queries.cpp
@@ -166,4 +166,7 @@ TEST_F(CommandGraphTest, NodeTypeQueries) {
   auto NodeSubgraph = Graph.add(
       [&](sycl::handler &cgh) { cgh.ext_oneapi_graph(SubgraphExec); });
   ASSERT_EQ(NodeSubgraph.get_type(), experimental::node_type::subgraph);
+
+  sycl::free(PtrA, Queue);
+  sycl::free(PtrB, Queue);
 }

--- a/sycl/unittests/Extensions/CommandGraph/Update.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Update.cpp
@@ -144,6 +144,9 @@ TEST_F(CommandGraphTest, UpdateNodeTypeExceptions) {
       cgh.set_arg(0, DynObj);
       cgh.ext_oneapi_graph(SubgraphExec);
     }));
+
+    sycl::free(PtrA, Queue);
+    sycl::free(PtrB, Queue);
   };
 
   experimental::dynamic_parameter DynamicParam{int{}};

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -120,12 +120,19 @@ thread_local bool TreatDeviceGlobalWriteEventAsCompleted = false;
 thread_local std::optional<ur_program_handle_t> ExpectedReadWriteURProgram =
     std::nullopt;
 
-static ur_result_t after_urUSMDeviceAlloc(void *pParams) {
+// Replaces the allocation instead of adjusting the pointer afterwards: the
+// default mock hands out a dummy handle, which would be leaked when the
+// pointer is swapped for the mock memory below.
+static ur_result_t replace_urUSMDeviceAlloc(void *pParams) {
   auto params = *static_cast<ur_usm_device_alloc_params_t *>(pParams);
   // Use the mock memory.
   **params.pppMem = MockDeviceGlobalMem;
   return UR_RESULT_SUCCESS;
 }
+
+// MockDeviceGlobalMem is not a dummy handle, so the default mock must not try
+// to release it as one.
+static ur_result_t replace_urUSMFree(void *) { return UR_RESULT_SUCCESS; }
 
 static ur_result_t after_urEnqueueUSMMemcpy(void *pParams) {
   auto params = *static_cast<ur_enqueue_usm_memcpy_params_t *>(pParams);
@@ -270,9 +277,12 @@ public:
   mock::getCallbacks().set_after_callback(#API, &after_##API)
 #define REDEFINE_AFTER_TEMPLATED(API, ...)                                     \
   mock::getCallbacks().set_after_callback(#API, &after_##API<__VA_ARGS__>)
+#define REDEFINE_REPLACE(API)                                                  \
+  mock::getCallbacks().set_replace_callback(#API, &replace_##API)
 
 TEST_F(DeviceGlobalTest, DeviceGlobalInitBeforeUse) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -299,7 +309,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalInitBeforeUse) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalInitialMemContents) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER(urEnqueueDeviceGlobalVariableRead);
 
@@ -321,7 +332,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalInitialMemContents) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUseFull) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -346,7 +358,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUseFull) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyToBeforeUseFull) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -371,7 +384,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyToBeforeUseFull) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUsePartialNoOffset) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -395,7 +409,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUsePartialNoOffset) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyToBeforeUsePartialNoOffset) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -419,7 +434,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyToBeforeUsePartialNoOffset) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUsePartialWithOffset) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -443,7 +459,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalCopyToBeforeUsePartialWithOffset) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalInitBeforeMemcpyToPartialWithOffset) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -467,7 +484,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalInitBeforeMemcpyToPartialWithOffset) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalCopyFromBeforeUse) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -484,7 +502,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalCopyFromBeforeUse) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyFromBeforeUse) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -501,7 +520,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalMemcpyFromBeforeUse) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalUseBeforeCopyTo) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);
@@ -523,7 +543,8 @@ TEST_F(DeviceGlobalTest, DeviceGlobalUseBeforeCopyTo) {
 }
 
 TEST_F(DeviceGlobalTest, DeviceGlobalUseBeforeMemcpyTo) {
-  REDEFINE_AFTER(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMDeviceAlloc);
+  REDEFINE_REPLACE(urUSMFree);
   REDEFINE_AFTER(urEnqueueUSMMemcpy);
   REDEFINE_AFTER_TEMPLATED(urEnqueueDeviceGlobalVariableWrite, true);
   REDEFINE_AFTER(urEventGetInfo);

--- a/sycl/unittests/Extensions/FreeFunctionCommands/FreeFunctionEventsHelpers.hpp
+++ b/sycl/unittests/Extensions/FreeFunctionCommands/FreeFunctionEventsHelpers.hpp
@@ -100,6 +100,10 @@ inline ur_result_t after_urEnqueueEventsWaitWithBarrier(void *pParams) {
 static size_t counter_urEnqueueHostTaskExp = 0;
 inline ur_result_t redefined_urEnqueueHostTaskExp(void *pParams) {
   ++counter_urEnqueueHostTaskExp;
+  auto params = *static_cast<ur_enqueue_host_task_exp_params_t *>(pParams);
+  // A real adapter always runs the callback, which takes ownership of the data
+  // the runtime allocated for it.
+  (*params.ppfnHostTask)(*params.pdata);
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -333,6 +333,9 @@ TEST(USMMemcpy2DTest, USMMemops2DSupported) {
   EXPECT_EQ(LastMemcpy2D.srcPitch, (size_t)5 * sizeof(long));
   EXPECT_EQ(LastMemcpy2D.width, (size_t)4 * sizeof(long));
   EXPECT_EQ(LastMemcpy2D.height, (size_t)2);
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }
 
 // Tests that the right fallback kernels are called when a backend does not
@@ -373,6 +376,9 @@ TEST(USMMemcpy2DTest, USMMemops2DUnsupported) {
   Q.ext_oneapi_copy2d(Ptr1, 5, Ptr2, 8, 4, 2);
   EXPECT_TRUE(LastMemopsQuery == UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT);
   EXPECT_EQ(LastEnqueuedKernel, USMMemcpyHelperKernelNameLong);
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }
 
 // Tests that the right paths are taken when the backend only supports native
@@ -419,6 +425,9 @@ TEST(USMMemcpy2DTest, USMFillSupportedOnly) {
   Q.ext_oneapi_copy2d(Ptr1, 5, Ptr2, 8, 4, 2);
   EXPECT_TRUE(LastMemopsQuery == UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT);
   EXPECT_EQ(LastEnqueuedKernel, USMMemcpyHelperKernelNameLong);
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }
 
 // Tests that the right paths are taken when the backend only supports native
@@ -467,6 +476,9 @@ TEST(USMMemcpy2DTest, USMMemsetSupportedOnly) {
   Q.ext_oneapi_copy2d(Ptr1, 5, Ptr2, 8, 4, 2);
   EXPECT_TRUE(LastMemopsQuery == UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT);
   EXPECT_EQ(LastEnqueuedKernel, USMMemcpyHelperKernelNameLong);
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }
 
 // Tests that the right paths are taken when the backend only supports native
@@ -525,6 +537,9 @@ TEST(USMMemcpy2DTest, USMMemcpySupportedOnly) {
   EXPECT_EQ(LastMemcpy2D.width, (size_t)4 * sizeof(long));
   EXPECT_EQ(LastMemcpy2D.height, (size_t)2);
   EXPECT_NE(LastEnqueuedKernel, USMMemcpyHelperKernelNameLong);
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }
 
 // Negative tests for cases where USM 2D memory operations are expected to throw
@@ -590,4 +605,7 @@ TEST(USMMemcpy2DTest, NegativeUSM2DOps) {
         << "Unexpected error code for ext_oneapi_copy2d with invalid "
            "destination pitch.";
   }
+
+  sycl::free(Ptr1, Q);
+  sycl::free(Ptr2, Q);
 }

--- a/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
+++ b/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
@@ -71,12 +71,6 @@ ur_result_t redefinedEventGetInfo(void *pParams) {
   return UR_RESULT_SUCCESS;
 }
 
-static ur_result_t redefinedEnqueueUSMFill(void *pParams) {
-  auto params = *static_cast<ur_enqueue_usm_fill_params_t *>(pParams);
-  **params.pphEvent = reinterpret_cast<ur_event_handle_t>(new int{});
-  return UR_RESULT_SUCCESS;
-}
-
 TEST(GetNative, GetNativeHandle) {
   sycl::unittest::UrMock<> Mock;
   sycl::platform Plt = sycl::platform();
@@ -96,8 +90,6 @@ TEST(GetNative, GetNativeHandle) {
   mock::getCallbacks().set_before_callback("urMemRetain", &redefinedMemRetain);
   mock::getCallbacks().set_before_callback("urMemBufferCreate",
                                            &redefinedMemBufferCreate);
-  mock::getCallbacks().set_before_callback("urEnqueueUSMFill",
-                                           &redefinedEnqueueUSMFill);
 
   context Context(Plt);
   queue Queue(Context, default_selector_v);
@@ -136,4 +128,6 @@ TEST(GetNative, GetNativeHandle) {
   // underlying handles
   ASSERT_EQ(TestCounter, 2 + DeviceRetainCounter - 1)
       << "get_native retained SYCL objects";
+
+  sycl::free(HostAlloc, Context);
 }

--- a/sycl/unittests/handler/require.cpp
+++ b/sycl/unittests/handler/require.cpp
@@ -128,7 +128,8 @@ TEST(Require, checkIfAccBoundedToHandler) {
     // void copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
     //           DestT* dest)
     {
-      int *ptr = new int(0);
+      int val = 0;
+      int *ptr = &val;
       try {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);
@@ -154,7 +155,8 @@ TEST(Require, checkIfAccBoundedToHandler) {
     //           accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder>
     //           dest)
     {
-      int *ptr = new int(0);
+      int val = 0;
+      int *ptr = &val;
       try {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);

--- a/sycl/unittests/helpers/UrMock.hpp
+++ b/sycl/unittests/helpers/UrMock.hpp
@@ -453,9 +453,21 @@ inline ur_result_t mock_urUsmP2PPeerAccessGetInfoExp(void *pParams) {
 
 inline ur_result_t mock_urVirtualMemReserve(void *pParams) {
   auto params = reinterpret_cast<ur_virtual_mem_reserve_params_t *>(pParams);
-  **params->pppStart = *params->ppStart
-                           ? const_cast<void *>(*params->ppStart)
-                           : mock::createDummyHandle<void *>(*params->psize);
+  // A caller-provided start address is echoed back as-is, so it is not a dummy
+  // handle and mock_urVirtualMemFree below must not release it. No in-tree
+  // caller does that, so catch it here rather than corrupting the heap later.
+  assert(!*params->ppStart &&
+         "the mock only supports reserving with a null start address");
+  **params->pppStart = mock::createDummyHandle<void *>(*params->psize);
+  return UR_RESULT_SUCCESS;
+}
+
+inline ur_result_t mock_urVirtualMemFree(void *pParams) {
+  auto params = reinterpret_cast<ur_virtual_mem_free_params_t *>(pParams);
+  // Mirrors mock_urVirtualMemReserve, which hands out a dummy handle as the
+  // range start. As with urUSMFree, the range is assumed to come from the mock,
+  // i.e. to have been reserved without a caller-provided start address.
+  mock::releaseDummyHandle(const_cast<void *>(*params->ppStart));
   return UR_RESULT_SUCCESS;
 }
 
@@ -618,6 +630,7 @@ public:
     ADD_DEFAULT_OVERRIDE(urUsmP2PPeerAccessGetInfoExp,
                          mock_urUsmP2PPeerAccessGetInfoExp)
     ADD_DEFAULT_OVERRIDE(urVirtualMemReserve, mock_urVirtualMemReserve)
+    ADD_DEFAULT_OVERRIDE(urVirtualMemFree, mock_urVirtualMemFree)
     ADD_DEFAULT_OVERRIDE(urVirtualMemGranularityGetInfo,
                          mock_urVirtualMemGranularityGetInfo)
     ADD_DEFAULT_OVERRIDE(urCommandBufferCreateExp,

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -137,6 +137,8 @@ TEST(QueueWait, QueueWaitTest) {
     ASSERT_EQ(TestContext.NEventsWaitedFor, 1);
     ASSERT_TRUE(TestContext.UrQueueFinishCalled);
   }
+
+  sycl::free(HostAlloc, Ctx);
 }
 
 } // namespace


### PR DESCRIPTION
## Problem

LeakSanitizer flagged these in an ASan+UBSan build (`-DLLVM_USE_SANITIZER=Address;Undefined`). LSan only reports memory that is unreachable at exit, and runtime global state is reachable from globals, so each of these is a genuine leak of test-owned memory. Three recurring patterns:

### A. `before`/`after` callbacks that leak the handle they hand out

A callback registered with `set_before_callback` (or `set_after_callback`) that writes an output handle is followed by the default mock, which creates its *own* handle and overwrites the pointer — so the callback's handle is leaked and the runtime releases the other one. Registering the callback as `set_replace_callback` fixes it, since the default body is then skipped.

- `Extensions/DeviceGlobal.cpp`: `after_urUSMDeviceAlloc` overwrote `**params.pppMem` with a static test array *after* the default mock had allocated a dummy handle (leak), and the subsequent `urUSMFree` then decremented a "reference counter" inside the test's own array, which UBSan reported as `member access within misaligned address ... for type 'dummy_handle_t_'`. Now a replace callback, paired with a no-op `urUSMFree` replace callback because the mock memory is not a dummy handle. 24 failing tests.
- `SYCL2020/GetNativeOpenCL.cpp`: a `before` callback on `urEnqueueUSMFill` did `**params.pphEvent = new int{}` — leaked, and a raw `new int` is not a releasable handle either. The default mock already produces a proper ref-counted dummy event, so the callback is removed entirely.

### B. Allocations and extension resources without their release

- `Extensions/USMMemcpy2D.cpp` (6 tests), `queue/Wait.cpp`, `Extensions/CommandGraph/{Update,Queries,InOrderQueue}.cpp`: `malloc_device`/`malloc_host`/`malloc_shared` with no `sycl::free`. The convention is already present elsewhere in these files (e.g. `CommandGraph/Exceptions.cpp`), these sites just missed it.
- `Extensions/BindlessImages/ImageDescriptors.cpp`: both `ImageDescriptorPropagates{Layout,SlicePitch}` acquired resources with `import_external_memory` + `map_external_image_memory` and never released them. Added `unmap_external_image_memory` + `release_external_memory`.
- `handler/require.cpp`: two `int *ptr = new int(0)` with no `delete`; replaced with a stack `int`.

### C. Mock entry points that free memory but did not release the handle

- `helpers/UrMock.hpp`: `mock_urVirtualMemReserve` hands out a dummy handle as the reserved range, but there was no matching free, so every graph async-allocation leaked its virtual reservation (`graph_mem_pool` reserves in `malloc()` and frees in `~graph_mem_pool()`). Added `mock_urVirtualMemFree`, mirroring the existing `urUSMFree` special case in the generated mock. It also asserts that the reserve had a null start address — a caller-provided start is echoed back verbatim and is therefore *not* a dummy handle, so releasing it would corrupt memory; no in-tree caller does that, and the assert names the problem if one ever does.
- `Extensions/FreeFunctionCommands/FreeFunctionEventsHelpers.hpp`: `redefined_urEnqueueHostTaskExp` never invoked the host-task callback, but `ExecCGCommand::enqueueImpQueue` transfers ownership of a heap-allocated `EnqueueHostTaskData` to it and only the callback deletes it. The mock now calls `(*params.ppfnHostTask)(*params.pdata)` like a real adapter.

## Verification

Per-test with leak checking, both Preview and Non-Preview variants: `USMMemcpy2DTest` 6/6, `QueueWait` 1/1, `CommandGraphExtensionTests` 118/118, `BindlessImagesExtensionTests` 10/10, `HandlerTests` 3/3, `ExtensionsTests` 251/249, `FreeFunctionCommands` 29/29 — all with no ASan/LSan/UBSan output.

Full `ninja check-sycl` in the sanitized build: 3516 passed, 0 failed.

Note: verified as part of a larger set of sanitizer fixes, not in isolation on top of pristine `sycl`. The `CommandGraphTest.AsyncAllocInfiniteLoop` result additionally depends on the UR mock command-handle ownership fix sent separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
