### PR TITLE
[SYCL] Make the scheduler unit tests clean up the commands they create

### DIFF
--- a/sycl/unittests/scheduler/AccessorDefaultCtor.cpp
+++ b/sycl/unittests/scheduler/AccessorDefaultCtor.cpp
@@ -40,4 +40,8 @@ TEST_F(SchedulerTest, AccDefaultCtorDoesntAffectDepGraph) {
   // if MDeps is empty, accessor built from default ctor does not affect
   // dependency graph in accordance with SYCL 2020
   EXPECT_TRUE(NewCmd->MDeps.empty());
+
+  // The command is owned by the graph and is never enqueued here, so it has to
+  // be deleted explicitly.
+  MS.cleanupCommand(NewCmd, /*AllowUnsubmitted=*/true);
 }

--- a/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
+++ b/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
@@ -15,6 +15,7 @@
 
 #include <sycl/usm.hpp>
 
+#include <set>
 #include <vector>
 
 namespace {
@@ -49,7 +50,30 @@ protected:
     QueueDevImpl = getSyclObjImpl(QueueDev);
   }
 
-  void TearDown() {}
+  void TearDown() {
+    // A host task's completion path keeps using its command after the event is
+    // marked complete, so the worker threads have to be done before anything is
+    // deleted below. The host task lambdas only take the fixture's mutex, which
+    // every test releases before returning, so this cannot deadlock.
+    detail::GlobalHandler::instance().drainThreadPool();
+
+    // Commands built here are owned by the graph and are normally deleted by
+    // post-enqueue cleanup, which this fixture disables. Take over the
+    // commands the runtime deferred instead of cleaning up (they would be
+    // deleted twice otherwise), re-enable cleanup and delete everything.
+    for (detail::Command *Cmd : MockScheduler::takeDeferredCleanupCommands())
+      CreatedCommands.insert(Cmd);
+    unittest::unset_env(DisableCleanupName);
+    detail::SYCLConfig<detail::SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::reset();
+    MS.cleanupCommands({CreatedCommands.begin(), CreatedCommands.end()});
+    CreatedCommands.clear();
+  }
+
+  void trackCommand(const event &Ev) {
+    if (auto *Cmd =
+            static_cast<detail::Command *>(getSyclObjImpl(Ev)->getCommand()))
+      CreatedCommands.insert(Cmd);
+  }
 
   detail::Command *
   AddTaskCG(TestCGType Type, const std::vector<EventImplPtr> &Events,
@@ -84,6 +108,7 @@ protected:
                  Type == TestCGType::HOST_TASK ? nullptr : QueueDevImpl.get(),
                  ToEnqueue, /*EventNeeded=*/true);
     EXPECT_EQ(ToEnqueue.size(), 0u);
+    CreatedCommands.insert(NewCmd);
     return NewCmd;
   }
 
@@ -155,6 +180,7 @@ protected:
       detail::SYCLConfig<detail::SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::reset};
   MockScheduler MS;
 
+  std::set<detail::Command *> CreatedCommands;
   std::shared_ptr<detail::queue_impl> QueueDevImpl;
 
   std::mutex m;
@@ -320,8 +346,10 @@ TEST_F(DependsOnTests, DISABLED_ShortcutFunctionWithWaitList) {
 #else
 TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
 #endif
-  mock::getCallbacks().set_before_callback("urEnqueueUSMMemcpy",
-                                           &redefinedextUSMEnqueueMemcpy);
+  // Replace, not before: the default mock would overwrite the event handle
+  // set below, leaking it.
+  mock::getCallbacks().set_replace_callback("urEnqueueUSMMemcpy",
+                                            &redefinedextUSMEnqueueMemcpy);
   sycl::queue Queue = detail::createSyclObjFromImpl<queue>(QueueDevImpl);
 
   // Mock up an incomplete host task
@@ -361,10 +389,16 @@ TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
   Queue.wait();
   sycl::free(FirstBuf, Queue);
   sycl::free(SecondBuf, Queue);
+
+  trackCommand(HostTaskEvent);
+  trackCommand(SingleTaskEvent);
+  trackCommand(ShortcutFuncEvent);
 }
 
 TEST_F(DependsOnTests, BarrierWithWaitList) {
-  mock::getCallbacks().set_before_callback(
+  // Replace, not before: the default mock would overwrite the event handle
+  // set below, leaking it.
+  mock::getCallbacks().set_replace_callback(
       "urEnqueueEventsWaitWithBarrierExt",
       &redefinedEnqueueEventsWaitWithBarrierExt);
   sycl::queue Queue = detail::createSyclObjFromImpl<queue>(QueueDevImpl);
@@ -390,10 +424,15 @@ TEST_F(DependsOnTests, BarrierWithWaitList) {
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
   EventsInWaitList.clear();
 
-  Queue.ext_oneapi_submit_barrier(std::vector<sycl::event>{SingleTaskEvent});
+  event BarrierEvent = Queue.ext_oneapi_submit_barrier(
+      std::vector<sycl::event>{SingleTaskEvent});
   EXPECT_NE(SingleTaskEventImpl.getHandle(), nullptr);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
   EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl.getHandle());
   Queue.wait();
+
+  trackCommand(HostTaskEvent);
+  trackCommand(SingleTaskEvent);
+  trackCommand(BarrierEvent);
 }
 } // anonymous namespace

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -27,26 +27,6 @@ using namespace sycl;
 
 inline constexpr auto HostUnifiedMemoryName = "SYCL_HOST_UNIFIED_MEMORY";
 
-int val;
-static ur_result_t redefinedEnqueueMemBufferMap(void *pParams) {
-  auto params = *static_cast<ur_enqueue_mem_buffer_map_params_t *>(pParams);
-  **params.pphEvent = reinterpret_cast<ur_event_handle_t>(new int{});
-  **params.pppRetMap = &val;
-  return UR_RESULT_SUCCESS;
-}
-
-static ur_result_t redefinedEnqueueMemUnmap(void *pParams) {
-  auto params = *static_cast<ur_enqueue_mem_unmap_params_t *>(pParams);
-  **params.pphEvent = reinterpret_cast<ur_event_handle_t>(new int{});
-  return UR_RESULT_SUCCESS;
-}
-
-static ur_result_t redefinedEnqueueMemBufferFill(void *pParams) {
-  auto params = *static_cast<ur_enqueue_mem_buffer_fill_params_t *>(pParams);
-  **params.pphEvent = reinterpret_cast<ur_event_handle_t>(new int{});
-  return UR_RESULT_SUCCESS;
-}
-
 static void verifyCleanup(detail::MemObjRecord *Record,
                           detail::AllocaCommandBase *AllocaCmd,
                           detail::Command *DeletedCmd, bool &CmdDeletedFlag) {
@@ -60,6 +40,19 @@ static void verifyCleanup(detail::MemObjRecord *Record,
                            [&](const detail::DepDesc &Dep) {
                              return Dep.MDepCommand == DeletedCmd;
                            }));
+}
+
+// Tears the record down the same way Scheduler::removeMemoryObject does: the
+// alloca commands have been enqueued, so their release commands have to be
+// enqueued as well to free the allocated memory.
+static void cleanupRecord(MockScheduler &MS, buffer<int, 1> &Buf,
+                          detail::MemObjRecord *Record) {
+  detail::EnqueueResultT Res;
+  for (detail::AllocaCommandBase *AllocaCmd : Record->MAllocaCommands)
+    MockScheduler::enqueueCommand(AllocaCmd->getReleaseCmd(), Res,
+                                  detail::BLOCKING);
+  MS.cleanupCommandsForRecord(Record);
+  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
 }
 
 // Check that any non-leaf commands enqueued as part of high level scheduler
@@ -155,11 +148,11 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
   // Check addCopyBack
   MockCmd = addNewMockCmds();
   LeafMockCmd->getEvent()->setHandle(
-      reinterpret_cast<ur_event_handle_t>(new int{}));
+      mock::createDummyHandle<ur_event_handle_t>());
   MS.addCopyBack(&MockReq);
   verifyCleanup(Record, AllocaCmd, MockCmd, CommandDeleted);
 
-  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
+  cleanupRecord(MS, Buf, Record);
 }
 
 static void checkCleanupOnLeafUpdate(
@@ -191,7 +184,7 @@ static void checkCleanupOnLeafUpdate(
   EXPECT_FALSE(CommandDeleted);
   SchedulerCall(Record);
   EXPECT_TRUE(CommandDeleted);
-  MS.removeRecordForMemObj(&*detail::getSyclObjImpl(Buf));
+  cleanupRecord(MS, Buf, Record);
 }
 
 TEST_F(SchedulerTest, PostEnqueueCleanup) {
@@ -201,13 +194,6 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
       detail::SYCLConfig<detail::SYCL_HOST_UNIFIED_MEMORY>::reset};
   sycl::unittest::UrMock<> Mock;
   sycl::platform Plt = sycl::platform();
-  mock::getCallbacks().set_before_callback("urEnqueueMemBufferMap",
-                                           &redefinedEnqueueMemBufferMap);
-  mock::getCallbacks().set_before_callback("urEnqueueMemUnmap",
-                                           &redefinedEnqueueMemUnmap);
-  mock::getCallbacks().set_before_callback("urEnqueueMemBufferFill",
-                                           &redefinedEnqueueMemBufferFill);
-
   context Ctx{Plt};
   queue Queue{Ctx, default_selector_v};
   detail::queue_impl &QueueImpl = *detail::getSyclObjImpl(Queue);
@@ -246,21 +232,23 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
   // Check cleanup on exceeding leaf limit.
   checkCleanupOnLeafUpdate(
       MS, &QueueImpl, Buf, MockReq, [&](detail::MemObjRecord *Record) {
-        std::vector<std::unique_ptr<MockCommand>> Leaves;
+        // The commands are added to the record, i.e. owned by the graph, and
+        // are deleted along with it.
+        std::vector<MockCommand *> Leaves;
         for (std::size_t I = 0;
              I < Record->MWriteLeaves.genericCommandsCapacity(); ++I)
-          Leaves.push_back(std::make_unique<MockCommand>(&QueueImpl, MockReq));
+          Leaves.push_back(new MockCommand(&QueueImpl, MockReq));
 
         detail::AllocaCommandBase *AllocaCmd = Record->MAllocaCommands[0];
         std::vector<detail::Command *> ToCleanUp;
-        for (std::unique_ptr<MockCommand> &MockCmd : Leaves) {
+        for (MockCommand *MockCmd : Leaves) {
           (void)MockCmd->addDep(detail::DepDesc(AllocaCmd, &MockReq, AllocaCmd),
                                 ToCleanUp);
-          MS.addNodeToLeaves(Record, MockCmd.get(), access::mode::read_write,
+          MS.addNodeToLeaves(Record, MockCmd, access::mode::read_write,
                              ToEnqueue);
         }
-        for (std::unique_ptr<MockCommand> &MockCmd : Leaves)
-          MS.updateLeaves({MockCmd.get()}, Record, access::mode::read_write,
+        for (MockCommand *MockCmd : Leaves)
+          MS.updateLeaves({MockCmd}, Record, access::mode::read_write,
                           ToCleanUp);
         EXPECT_TRUE(ToCleanUp.empty());
       });
@@ -317,19 +305,19 @@ TEST_F(SchedulerTest, StreamBufferDeallocation) {
   AttachSchedulerWrapper AttachScheduler{MSPtr};
   detail::EventImplPtr EventImplPtr;
   {
-    MockHandlerCustomFinalize MockCGH(QueueImpl,
-                                      /*CallerNeedsEvent=*/true);
     kernel_bundle KernelBundle =
         sycl::get_kernel_bundle<sycl::bundle_state::input>(
             QueueImpl.get_context());
     auto ExecBundle = sycl::build(KernelBundle);
-    MockCGH.use_kernel_bundle(ExecBundle);
-    stream Stream{1, 1, MockCGH};
-    MockCGH.addStream(detail::getSyclObjImpl(Stream));
-    MockCGH.single_task<TestKernel>([] {});
-    std::unique_ptr<detail::CG> CG = MockCGH.finalize();
-
-    EventImplPtr = MSPtr->addCG(std::move(CG), QueueImpl, /*EventNeeded=*/true);
+    // Submit through the queue: the stream flush command it appends is what
+    // takes the kernel command out of the leaves of the stream buffers, which
+    // in turn lets graph cleanup delete the command and release the buffers.
+    event Ev = Queue.submit([&](handler &CGH) {
+      CGH.use_kernel_bundle(ExecBundle);
+      stream Stream{1, 1, CGH};
+      CGH.single_task<TestKernel>([] {});
+    });
+    EventImplPtr = detail::getSyclObjImpl(Ev);
   }
 
   // The buffers should have been released with graph cleanup once the work is

--- a/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
+++ b/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
@@ -9,7 +9,6 @@
 #include "SchedulerTest.hpp"
 #include "SchedulerTestUtils.hpp"
 
-#include <helpers/ScopedEnvVar.hpp>
 #include <helpers/TestKernel.hpp>
 #include <helpers/UrMock.hpp>
 
@@ -20,8 +19,6 @@
 namespace {
 using namespace sycl;
 using EventImplPtr = std::shared_ptr<sycl::detail::event_impl>;
-
-constexpr auto DisableCleanupName = "SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP";
 
 class TestQueueImpl : public sycl::detail::queue_impl {
 public:
@@ -129,10 +126,6 @@ protected:
   }
 
   sycl::unittest::UrMock<> Mock;
-  sycl::unittest::ScopedEnvVar DisabledCleanup{
-      DisableCleanupName, "1",
-      sycl::detail::SYCLConfig<
-          detail::SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP>::reset};
   std::shared_ptr<TestQueueImpl> QueueDevImpl;
 
   std::mutex m;

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -48,6 +48,8 @@ TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
 
   size_t expectedCount = 1u;
   EXPECT_EQ(GEventsWaitCounter, expectedCount);
+
+  sycl::free(buf, InOrderQueue);
 }
 
 enum class CommandType { KERNEL = 1, MEMSET = 2, HOST_TASK = 3 };
@@ -125,6 +127,8 @@ TEST_F(SchedulerTest, InOrderQueueCrossDeps) {
   EXPECT_EQ(std::get<0>(ExecutedCommands[2]) /*CommandType*/,
             CommandType::KERNEL);
   EXPECT_EQ(std::get<1>(ExecutedCommands[2]) /*EventsCount*/, 0u);
+
+  sycl::free(buf, InOrderQueue);
 }
 
 TEST_F(SchedulerTest, InOrderQueueCrossDepsShortcutFuncs) {
@@ -176,6 +180,8 @@ TEST_F(SchedulerTest, InOrderQueueCrossDepsShortcutFuncs) {
   EXPECT_EQ(std::get<0>(ExecutedCommands[2]) /*CommandType*/,
             CommandType::KERNEL);
   EXPECT_EQ(std::get<1>(ExecutedCommands[2]) /*EventsCount*/, 0u);
+
+  sycl::free(buf, InOrderQueue);
 }
 
 TEST_F(SchedulerTest, InOrderQueueCrossDepsShortcutFuncsParallelFor) {

--- a/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
+++ b/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
@@ -144,7 +144,15 @@ TEST_F(SchedulerTest, LeafLimitDiffContexts) {
   // ConnectCmd is created internally in scheduler and not a mock object
   // This fact leads to active scheduler shutdown process that deletes a
   // part of commands for record we store in AddedLeaves vector.
-  // We abort this process by removing record to avoid double release or
-  // or memory leaks
+  // We abort this process by removing record to avoid double release.
+  // The commands the graph builder created on its own (the connect command and
+  // the alloca commands) have to be deleted by hand then.
+  detail::Command *ConnectCmd = *ConnectCmdIt;
+  std::vector<detail::Command *> GraphOwnedCmds{
+      ExtQueue1.Rec->MAllocaCommands.begin(),
+      ExtQueue1.Rec->MAllocaCommands.end()};
   MS.removeRecordForMemObj(MockReq.MSYCLMemObj);
+  delete ConnectCmd;
+  for (detail::Command *Cmd : GraphOwnedCmds)
+    delete Cmd;
 }

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -108,4 +108,9 @@ TEST_F(SchedulerTest, LinkedAllocaDependencies) {
                              return Dep.MDepCommand == &DepCmd;
                            }) != AllocaCmd2->MDeps.end())
       << "No deps for leaves (deps of existing alloca) appeared in new alloca";
+
+  // The new alloca command is owned by the graph. The mocked record can't be
+  // cleaned up through the scheduler since AllocaCmd1 is not heap allocated,
+  // so delete the command directly.
+  delete AllocaCmd2;
 }

--- a/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
+++ b/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
@@ -212,5 +212,9 @@ TEST_F(SchedulerTest, NoHostUnifiedMemory) {
 
     EXPECT_EQ(Record->MAllocaCommands.size(), 1U);
     EXPECT_EQ(InteropAlloca->MMemAllocation, MockInteropBuffer);
+
+    // buffer_impl retained the native handle, drop the reference owned by the
+    // test.
+    mock::releaseDummyHandle(MockInteropBuffer);
   }
 }

--- a/sycl/unittests/scheduler/QueueFlushing.cpp
+++ b/sycl/unittests/scheduler/QueueFlushing.cpp
@@ -254,4 +254,12 @@ TEST_F(SchedulerTest, QueueFlushing) {
     MockScheduler::enqueueCommand(&CmdA, Res, detail::NON_BLOCKING);
     EXPECT_FALSE(EventStatusQueried);
   }
+
+  // AllocaCmd is a stack object with no matching release command, so free its
+  // allocation by hand: both the one set up above and the one the enqueue
+  // replaced it with.
+  if (AllocaCmd.MMemAllocation != URBuf)
+    mock::releaseDummyHandle(
+        static_cast<ur_mem_handle_t>(AllocaCmd.MMemAllocation));
+  mock::releaseDummyHandle(URBuf);
 }

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -193,6 +193,23 @@ public:
     return MGraphBuilder.addEmptyCmd(Cmd, Reqs, Reason, ToEnqueue);
   }
 
+  // Takes over the commands the runtime deferred for cleanup. Tests that
+  // disable execution graph cleanup have to delete such commands themselves,
+  // and leaving them in the deferred list would make
+  // Scheduler::releaseResources delete them a second time.
+  static std::vector<sycl::detail::Command *> takeDeferredCleanupCommands() {
+    sycl::detail::Scheduler &Sched = sycl::detail::Scheduler::getInstance();
+    std::vector<sycl::detail::Command *> Cmds;
+    std::lock_guard<std::mutex> Lock{Sched.MDeferredCleanupMutex};
+    std::swap(Cmds, Sched.MDeferredCleanupCommands);
+    return Cmds;
+  }
+
+  void cleanupCommand(sycl::detail::Command *Cmd,
+                      bool AllowUnsubmitted = false) {
+    MGraphBuilder.cleanupCommand(Cmd, AllowUnsubmitted);
+  }
+
   sycl::detail::Command *addCG(std::unique_ptr<sycl::detail::CG> CommandGroup,
                                sycl::detail::queue_impl *Queue,
                                std::vector<sycl::detail::Command *> &ToEnqueue,


### PR DESCRIPTION
## Problem and fixes

All found in an ASan+UBSan build (`-DLLVM_USE_SANITIZER=Address;Undefined`). Scheduler `Command` objects are owned by the graph through raw pointers and deleted by `GraphBuilder::cleanupCommand()`; a test that creates commands and never lets them complete leaves them unreachable, and because `Command::MQueue` is a `shared_ptr<queue_impl>` each orphan also pins a queue, its context and the kernel/program caches. That is why the reports are large and consist of *indirect* leaks with no direct leak.

### `HostTaskAndBarrier.cpp` — 20 failing tests, fixed by deleting three lines

The `BarrierHandlingWithHostTask` fixture set `SYCL_DISABLE_EXECUTION_GRAPH_CLEANUP=1` via a `ScopedEnvVar` member. With it set, `Command::enqueue()` never pushes commands onto `ToCleanUp` and `GraphBuilder::cleanupCommand()` returns early, so every `ExecCGCommand` the tests create is permanently orphaned. The variable was not load-bearing: it arrived with the file's original commit and the tests only ever inspect `event_impl` state (`getWaitList()` reads `MPreparedDepsEvents`, which lives on the event, and `~Command()` only clears the *dependency* events' lists). Removing it restores the default cleanup path and the cluster frees itself.

### `GraphCleanup.cpp` — fake handles and a `unique_ptr` the graph outlives

- Three `before` callbacks on `urEnqueueMemBufferMap`/`urMemUnmap`/`urEnqueueMemBufferFill` handed out `reinterpret_cast<ur_event_handle_t>(new int{})`. Those leak, and once commands are really destroyed, `urEventRelease` on them is a **heap-buffer-overflow** (the mock decrements a reference counter inside a 4-byte allocation). The default mock already returns a proper ref-counted dummy event and a valid map pointer, so the callbacks are removed.
- The leaf-limit lambda held its commands in `unique_ptr<MockCommand>`; the pointers died while the memory-object record still referenced them, giving a use-after-free during cleanup. They are now plain graph-owned commands.
- New `cleanupRecord()` helper mirroring `Scheduler::removeMemoryObject()` (enqueue each alloca's release command, then `cleanupCommandsForRecord` + `removeRecordForMemObj`), used by both `checkCleanupOnEnqueue` and `checkCleanupOnLeafUpdate`.

### `EnqueueWithDependsOnDeps.cpp` — take over deferred commands before deleting

`DependsOnTests` disables graph cleanup, so its `TearDown()` has to delete the commands itself. Deleting them naively double-frees: the runtime may already have queued the same command in `Scheduler::MDeferredCleanupCommands`, and `~UrMock` -> `Scheduler::releaseResources()` -> `cleanupCommands()` then deletes it a second time (observed as a heap-use-after-free at `graph_builder.cpp` `cleanupCommand`). `TearDown()` now drains that list first (new `MockScheduler::takeDeferredCleanupCommands()`), re-enables cleanup and deletes each tracked command exactly once.

It also calls `GlobalHandler::instance().drainThreadPool()` first: a host task's completion path keeps using its command *after* the event is marked complete, so a worker thread could still be inside `NotifyHostTaskCompletion()` while `TearDown()` deletes it (a real, if rare, use-after-free). The host-task lambdas in this file only take the fixture's mutex, which every test releases before returning, so this cannot deadlock.

### Remaining files

- `StreamBufferDeallocation` (in `GraphCleanup.cpp`) now submits through `Queue.submit` instead of `MockHandlerCustomFinalize` + `addCG`: only `queue_impl::submit_impl` appends the per-stream flush host task that removes the kernel command from the stream buffers' leaves, which is what lets cleanup break the command <-> stream-buffer cycle. This also cleared 25 `ProgramManager::addImage` blocks that looked like a static-initializer leak but were the kernel bundle held by the leaked command.
- `AccessorDefaultCtor.cpp`: `MS.cleanupCommand(NewCmd, /*AllowUnsubmitted=*/true)` — the command is never enqueued, so plain `cleanupCommands` would trip the assertion.
- `LinkedAllocaDependencies.cpp`: `delete AllocaCmd2` (the record cannot go through the scheduler because `AllocaCmd1` is a stack object).
- `LeafLimitDiffContexts.cpp`: delete the graph-builder-created commands after `removeRecordForMemObj`.
- `NoHostUnifiedMemory.cpp`: `mock::releaseDummyHandle(MockInteropBuffer)` — `buffer_impl` retains the native handle, the test never dropped its own reference.
- `InOrderQueueHostTaskDeps.cpp`: three missing `sycl::free`.
- `QueueFlushing.cpp`: the test's `AllocaCommand` is a stack object with no release command, and enqueueing it replaces `MMemAllocation`, orphaning the handle the test installed; both are now released.
- `SchedulerTestUtils.hpp`: new `MockScheduler::takeDeferredCleanupCommands()` and `cleanupCommand(Cmd, AllowUnsubmitted)` accessors used above.

## Verification

- `SchedulerTests-Non_Preview_Tests`: 67/67 over 5 consecutive runs, zero leaks, zero ASan reports (the threading in these tests makes repeated runs worthwhile).
- Assertions mutation-checked in `HostTaskAndBarrier.cpp` (barrier wait-list size, host-task wait-list size, `UnenqueuedCmdEvents` size): each fails when flipped, so the tests are not passing vacuously. 300/300 with `--gtest_repeat=30`.
- Full `ninja check-sycl` in the sanitized build: 3516 passed, 0 failed.

Note: verified as part of a larger set of sanitizer fixes, not in isolation on top of pristine `sycl`. Leak-freedom of `SchedulerTest.FailedCopyBackException` additionally depends on the `SYCLMemObjT::updateHostMemory()` fix sent separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
