### PR TITLE
[SYCL][LIT] Support running check-sycl against a sanitized runtime

### DIFF
--- a/sycl/test/Unit-Preview/lit.cfg.py
+++ b/sycl/test/Unit-Preview/lit.cfg.py
@@ -55,6 +55,14 @@ for symbolizer in ["ASAN_SYMBOLIZER_PATH", "MSAN_SYMBOLIZER_PATH"]:
 llvm_symbolizer = os.path.join(config.llvm_tools_dir, "llvm-symbolizer")
 config.environment["LLVM_SYMBOLIZER_PATH"] = llvm_symbolizer
 
+# Ignore leaks that come from libraries this project does not build, e.g. the
+# Level Zero loader's global context, which the tests that enumerate real
+# platforms pull in. Only used when the runtime was built with the address
+# sanitizer; harmless otherwise.
+config.environment["LSAN_OPTIONS"] = "suppressions=" + os.path.join(
+    os.path.dirname(__file__), os.pardir, "lsan_suppressions.txt"
+)
+
 
 def find_shlibpath_var():
     if platform.system() in ["Linux", "FreeBSD", "NetBSD", "SunOS"]:

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -57,6 +57,14 @@ for symbolizer in ["ASAN_SYMBOLIZER_PATH", "MSAN_SYMBOLIZER_PATH"]:
 llvm_symbolizer = os.path.join(config.llvm_tools_dir, "llvm-symbolizer")
 config.environment["LLVM_SYMBOLIZER_PATH"] = llvm_symbolizer
 
+# Ignore leaks that come from libraries this project does not build, e.g. the
+# Level Zero loader's global context, which the tests that enumerate real
+# platforms pull in. Only used when the runtime was built with the address
+# sanitizer; harmless otherwise.
+config.environment["LSAN_OPTIONS"] = "suppressions=" + os.path.join(
+    os.path.dirname(__file__), os.pardir, "lsan_suppressions.txt"
+)
+
 
 def find_shlibpath_var():
     if platform.system() in ["Linux", "FreeBSD", "NetBSD", "SunOS"]:

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -68,6 +68,33 @@ if config.extra_environment:
             lit_config.note("\tUnset " + var)
             llvm_config.with_environment(var, "")
 
+# Tests are not compiled with -fsanitize=address (that would also instrument
+# device code and change what the check_device_code tests match), so a host
+# binary loading a sanitized libsycl needs the ASan runtime loaded first.
+# Preload it, and ignore the leaks of the system tools a RUN line invokes, which
+# get leak-checked as a side effect of being started by a preloaded process.
+# A test that sets LD_PRELOAD itself must prepend %{asan_preload} to keep the
+# runtime first; it expands to nothing in a regular build.
+AsanPreload = ""
+if "Address" in getattr(config, "llvm_use_sanitizer", ""):
+    AsanRuntime = subprocess.check_output(
+        [config.host_cxx, "-print-file-name=libclang_rt.asan-x86_64.so"],
+        text=True,
+    ).strip()
+    if os.path.isfile(AsanRuntime):
+        AsanPreload = AsanRuntime + ":"
+        llvm_config.with_environment("LD_PRELOAD", AsanRuntime)
+        llvm_config.with_environment(
+            "LSAN_OPTIONS",
+            "suppressions="
+            + os.path.join(config.test_source_root, "lsan_suppressions.txt"),
+        )
+    else:
+        lit_config.warning(
+            "sanitized build, but no ASan runtime found: {}".format(AsanRuntime)
+        )
+config.substitutions.append(("%{asan_preload}", AsanPreload))
+
 # If major release preview library is enabled we can enable the feature.
 if config.sycl_preview_lib_enabled == "ON":
     config.available_features.add("preview-breaking-changes-supported")

--- a/sycl/test/lit.site.cfg.py.in
+++ b/sycl/test/lit.site.cfg.py.in
@@ -25,6 +25,8 @@ config.test_include_path = "@TEST_INCLUDE_PATH@"
 
 config.llvm_enable_projects = "@LLVM_ENABLE_PROJECTS@"
 config.install_bin_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+config.host_cxx = "@CMAKE_CXX_COMPILER@"
 
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.sycl_use_libcxx = 'ON' if @LLVM_LIBCXX_USED@ else 'OFF'

--- a/sycl/test/lsan_suppressions.txt
+++ b/sycl/test/lsan_suppressions.txt
@@ -1,0 +1,30 @@
+# LeakSanitizer suppressions for running these tests against a runtime built
+# with -DLLVM_USE_SANITIZER=Address.
+#
+# A sanitized RUN line leak-checks every process it starts, including the system
+# tools it invokes, so everything listed here is a leak in code this project
+# does not build. Never add a SYCL runtime, LLVM or clang frame here.
+
+# GNU ld and gold allocate from an arena that is never freed.
+leak:x86_64-linux-gnu-ld.bfd
+leak:libbfd
+leak:ld.gold
+
+# System toolchain used by a few tests that compile with the host compiler.
+# Frames in these are unsymbolized, so the module name is what matches.
+leak:cc1plus
+leak:x86_64-linux-gnu-g++
+leak:x86_64-linux-gnu-gcc
+leak:/usr/bin/g++
+leak:/usr/bin/gcc
+
+# Coreutils used from RUN lines. They close stderr in an atexit handler, so the
+# report itself is invisible and only shows up as a non-zero exit code.
+leak:/usr/bin/sort
+leak:/usr/bin/sed
+leak:/usr/bin/grep
+
+# The Level Zero loader's global context singleton: the vendor libze_loader has
+# no API to tear it down.
+leak:libze_loader
+leak:loader::context_t::init

--- a/sycl/test/tools/render-group.cpp
+++ b/sycl/test/tools/render-group.cpp
@@ -1,16 +1,18 @@
 // REQUIRES: linux
 
 // Compile Inputs/mock_renderd_access.c to a shared library and then use
-// LD_PRELOAD to mock the stat and open functions.
+// LD_PRELOAD to mock the stat and open functions. %{asan_preload} keeps the
+// sanitizer runtime first in the list when the runtime is built with ASan and
+// expands to nothing otherwise.
 // RUN: %clang -shared -fPIC -o %t-mock_stat.so %S/Inputs/mock_renderd_access.c
 
 // Check the case when /dev/dri/renderD12* don't exist.
-// RUN: env MOCK_GLOB_MODE=notfound LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s -check-prefix=CHECK-NOTFOUND
+// RUN: env MOCK_GLOB_MODE=notfound LD_PRELOAD=%{asan_preload}%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s -check-prefix=CHECK-NOTFOUND
 // We don't expect any warning about permissions in this case.
 // CHECK-NOTFOUND-NOT: WARNING: Unable to access /dev/dri/renderD12
 
 // Check the case when /dev/dri/renderD12* exist but not accessible.
-// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=deny LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-DENY
+// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=deny LD_PRELOAD=%{asan_preload}%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-DENY
 // CHECK-DENY: WARNING: Unable to access /dev/dri/renderD128 due to permissions (EACCES).
 // CHECK-DENY-NEXT: You might be missing the 'render' group locally.
 // CHECK-DENY-NEXT: Try: sudo usermod -a -G render $USER
@@ -18,7 +20,7 @@
 
 // Check the case when /dev/dri/renderD12* exist but only the first one is
 // accessible.
-// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=deny_second LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-DENY-SECOND
+// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=deny_second LD_PRELOAD=%{asan_preload}%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-DENY-SECOND
 // CHECK-DENY-SECOND-NOT: WARNING: Unable to access /dev/dri/renderD128 due to permissions (EACCES).
 // CHECK-DENY-SECOND: WARNING: Unable to access /dev/dri/renderD129 due to permissions (EACCES).
 // CHECK-DENY-SECOND-NEXT: You might be missing the 'render' group locally.
@@ -26,5 +28,5 @@
 // CHECK-DENY-SECOND-NEXT: Then log out and log back in.
 
 // Check the case when /dev/dri/renderD12* exist and is accessible.
-// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=allow LD_PRELOAD=%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-GRANT
+// RUN: env MOCK_GLOB_MODE=exists MOCK_OPEN_MODE=allow LD_PRELOAD=%{asan_preload}%t-mock_stat.so sycl-ls --verbose --ignore-device-selectors 2>&1 | FileCheck %s --check-prefix=CHECK-GRANT
 // CHECK-GRANT-NOT: WARNING: Unable to access /dev/dri/renderD12


### PR DESCRIPTION
## Motivation

`ninja check-sycl` does not work against a runtime built with `-DLLVM_USE_SANITIZER=Address`: the tests compile host binaries with the just-built `clang++` *without* `-fsanitize=address`, and those binaries then load an ASan-instrumented `libsycl.so`. ASan refuses that unless its runtime comes first in the initial library list:

```
==...==ASan runtime does not come first in initial library list; you should
either link runtime to your application or manually preload it with LD_PRELOAD.
```

That accounted for 28 test failures in a sanitized build. Setting `LD_PRELOAD` in the calling shell is not a workaround: LeakSanitizer then also checks lit's own `python3` process, and `check-sycl-jit` fails on python's interpreter allocations.

## What this adds

**1. `sycl/test/lit.cfg.py`** — when `config.llvm_use_sanitizer` contains `Address`, preload the host compiler's ASan runtime into the test environment and point LSan at a suppressions file:

```python
AsanRuntime = subprocess.check_output(
    [config.host_cxx, "-print-file-name=libclang_rt.asan-x86_64.so"], text=True).strip()
if os.path.isfile(AsanRuntime):
    AsanPreload = AsanRuntime + ":"
    llvm_config.with_environment("LD_PRELOAD", AsanRuntime)
    llvm_config.with_environment("LSAN_OPTIONS", "suppressions=" + ...)
```

`config.llvm_use_sanitizer` and `config.host_cxx` are plumbed through `lit.site.cfg.py.in`. In a regular build nothing changes.

**2. `sycl/test/lsan_suppressions.txt`** — `LD_PRELOAD` applies to the whole RUN line, so the tools a RUN line invokes get leak-checked too. The suppressions cover only code this project does not build:

- GNU `ld.bfd` / `libbfd` / `ld.gold`, which allocate from an arena and never free it (e.g. 22 KB from `xmalloc` for `matrix/compile-query.cpp`);
- the system toolchain used by the few tests that compile with `g++`;
- coreutils (`sort`, `sed`, `grep`) invoked from RUN lines — these were the most confusing failures, because coreutils close stderr in an `atexit` handler, so the LSan report is swallowed and the test just exits 1 with no output;
- the Level Zero loader's global context singleton in the prebuilt vendor `libze_loader`, which has no teardown entry point.

The file states the rule explicitly: no SYCL runtime, LLVM or clang frame belongs in it.

**3. `sycl/test/Unit/lit.cfg.py`, `sycl/test/Unit-Preview/lit.cfg.py`** — point the unit-test suites at the same suppressions file. Unit test binaries are instrumented already, so they need no preload, but `AllowListTests` enumerates real platforms and so pulls in the Level Zero loader.

**4. `sycl/test/tools/render-group.cpp`** — this test sets its own `LD_PRELOAD` to mock `stat`/`glob`, which dropped the ASan runtime and made instrumented `sycl-ls` abort. It now prepends the new `%{asan_preload}` substitution, which expands to nothing in a regular build.

## Why not `-fsanitize=address` on the test compile line

That would be cleaner (no preload, no suppressions, system tools untouched), but with `-fsycl` it also enables the *device* sanitizer, changing the IR that the `check_device_code` tests match. `-Xarch_host -fsanitize=address` avoids that, but cannot link in this configuration because a sanitizer-only build does not include compiler-rt. Worth revisiting if `LLVM_ENABLE_RUNTIMES=compiler-rt` becomes standard for such builds.

One more thing worth recording: the preload is not optional. `libsycl.so` built with `-shared-libasan` has a `DT_NEEDED` on the ASan runtime, so the runtime *is* loaded even without the preload — but too late to intercept `malloc`, and LeakSanitizer then silently reports nothing. Verified with a deliberately leaking probe binary: no preload, no report.

## Verification

`ninja check-sycl` in a build configured with

```
-DLLVM_USE_SANITIZER=Address;Undefined
-DCMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS="-shared-libasan -Wl,-rpath,<asan runtime dir>"
```

now completes: **3598 discovered, 3516 passed, 0 failed**, 77 unsupported, 4 skipped, 1 XFAIL (it was 256 failures before this and the accompanying code fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
