### PR TITLE
[UR][OpenCL] Break reference cycle between in-order queue and last event

### DIFF
--- a/unified-runtime/source/adapters/opencl/event.hpp
+++ b/unified-runtime/source/adapters/opencl/event.hpp
@@ -72,7 +72,7 @@ inline ur_result_t createUREvent(cl_event Event, ur_context_handle_t Context,
     try {
       auto UREvent =
           std::make_unique<ur_event_handle_t_>(Event, cast(Context), UrQueue);
-      UR_RETURN_ON_FAILURE(UrQueue->storeLastEvent(cast(UREvent.get())));
+      UR_RETURN_ON_FAILURE(UrQueue->storeLastEvent(Event));
       *ReturnedEvent = cast(UREvent.release());
     } catch (std::bad_alloc &) {
       return UR_RESULT_ERROR_OUT_OF_RESOURCES;

--- a/unified-runtime/source/adapters/opencl/queue.cpp
+++ b/unified-runtime/source/adapters/opencl/queue.cpp
@@ -194,11 +194,11 @@ ur_result_t urQueueGetInfo(ur_queue_handle_t hQueue, ur_queue_info_t propName,
       }
       return ReturnValue(false);
     } else {
-      ur_event_status_t Status;
-      UR_RETURN_ON_FAILURE(ur::opencl::urEventGetInfo(
-          cast(Queue->LastEvent), UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
-          sizeof(ur_event_status_t), (void *)&Status, nullptr));
-      if (Status == UR_EVENT_STATUS_COMPLETE) {
+      cl_int QueryResult;
+      CL_RETURN_ON_FAILURE(
+          clGetEventInfo(Queue->LastEvent, CL_EVENT_COMMAND_EXECUTION_STATUS,
+                         sizeof(QueryResult), &QueryResult, nullptr));
+      if (QueryResult == CL_COMPLETE) {
         return ReturnValue(true);
       }
       return ReturnValue(false);

--- a/unified-runtime/source/adapters/opencl/queue.hpp
+++ b/unified-runtime/source/adapters/opencl/queue.hpp
@@ -27,7 +27,11 @@ struct ur_queue_handle_t_ : handle_base {
   bool IsNativeHandleOwned = true;
   // Used to implement UR_QUEUE_INFO_EMPTY query
   bool IsInOrder;
-  ur_event_handle_t_ *LastEvent = nullptr;
+  // Native event of the last command enqueued on an in-order queue. This is a
+  // cl_event and not a ur_event_handle_t_ because a UR event retains its queue,
+  // so holding the UR event here would make queue and event keep each other
+  // alive forever.
+  cl_event LastEvent = nullptr;
   ur::RefCount RefCount;
 
   ur_queue_handle_t_(const ur_queue_handle_t_ &) = delete;
@@ -47,6 +51,9 @@ struct ur_queue_handle_t_ : handle_base {
                                     ur_queue_handle_t &Queue);
 
   ~ur_queue_handle_t_() {
+    if (LastEvent) {
+      clReleaseEvent(LastEvent);
+    }
     ur::opencl::urDeviceRelease(cast(Device));
     ur::opencl::urContextRelease(cast(Context));
     if (IsNativeHandleOwned) {
@@ -59,16 +66,16 @@ struct ur_queue_handle_t_ : handle_base {
 
   // Stores last event for in-order queues. Has no effect if queue is Out Of
   // Order. The last event is used to implement UR_QUEUE_INFO_EMPTY query.
-  ur_result_t storeLastEvent(ur_event_handle_t Event) {
+  ur_result_t storeLastEvent(cl_event Event) {
     if (!IsInOrder) {
       return UR_RESULT_SUCCESS;
     }
     if (LastEvent) {
-      UR_RETURN_ON_FAILURE(ur::opencl::urEventRelease(cast(LastEvent)));
+      CL_RETURN_ON_FAILURE(clReleaseEvent(LastEvent));
     }
-    LastEvent = cast(Event);
+    LastEvent = Event;
     if (LastEvent) {
-      UR_RETURN_ON_FAILURE(ur::opencl::urEventRetain(cast(LastEvent)));
+      CL_RETURN_ON_FAILURE(clRetainEvent(LastEvent));
     }
     return UR_RESULT_SUCCESS;
   }


### PR DESCRIPTION
## Problem

`ur_queue_handle_t_::storeLastEvent()` retained the `ur_event_handle_t_` it stores (`queue.hpp:71`), and `ur_event_handle_t_`'s constructor retains its `Queue` (`event.hpp:31`). For an **in-order** queue that is an unbreakable cycle:

- queue -> `LastEvent` (strong, via `urEventRetain`)
- event -> `Queue` (strong, via `urQueueRetain`)

The queue's reference count never reaches zero, so `~ur_queue_handle_t_` never runs and its `urContextRelease` / `urDeviceRelease` never fire. The queue, its context, its device and the event are all leaked for the lifetime of the process.

`storeLastEvent()` is called on **every** enqueue to an in-order queue, so this is not an edge case: it affects any `sycl::queue` created with the `in_order` property. It is in the shared OpenCL adapter, so it applies to `opencl:gpu` as well as `opencl:cpu`.

## Fix

Store the `cl_event` instead of the UR event, retained with `clRetainEvent` and released in the destructor. The queue only ever needed that event to answer `UR_QUEUE_INFO_EMPTY`, and a `cl_event` holds no reference back to the UR queue, so the cycle cannot form.

The `UR_QUEUE_INFO_EMPTY` query now calls `clGetEventInfo(CL_EVENT_COMMAND_EXECUTION_STATUS)` directly, which is the identical call the neighbouring branch for a queue with no stored event already made.

## How it was found

An ASan+UBSan build of the runtime running `sycl/test-e2e/Basic` on `opencl:cpu`. LeakSanitizer reported it as **four indirect leaks with no direct leak at all**, which is the signature of a reference cycle (no chunk is unreferenced, so nothing qualifies as the root):

```
Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #2 ur::opencl::urQueueCreate(...) queue.cpp:165
Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #2 ur::opencl::urContextCreate(...) context.cpp:84
Indirect leak of 40 byte(s) in 1 object(s) allocated from:
    #2 ur::opencl::createUREvent(...) event.hpp:74
Indirect leak of 8 byte(s) in 1 object(s)
SUMMARY: AddressSanitizer: 176 byte(s) leaked in 4 allocation(s).
```

## Testing

Reproduced by existing tests, no new test needed:

- `Basic/khr_flush.cpp`
- `Basic/in_order_queue_status_khr_empty.cpp`
- `Basic/in_order_queue_status_ext_oneapi_empty.cpp`

All three leaked before and are clean after. The `out_of_order_*` siblings were never affected, matching the `IsInOrder` gate.

Mutation-checked: inverting the `QueryResult == CL_COMPLETE` comparison this PR rewrites makes `in_order_queue_status_khr_empty.cpp` fail its `Q.khr_empty()` assertion at line 56, so the rewritten branch is genuinely exercised and the test is not vacuous.

Re-ran the surrounding 28-test batch of `sycl/test-e2e/Basic` on `opencl:cpu`: identical pass/fail set, no new assertion failures. The remaining failures in that batch are an unrelated leak in the closed-source OpenCL CPU driver (`Intel::OpenCL::Framework::DeviceProgram::initializeAllKernelArgsInfoFromIRData`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)