### PR TITLE
[SYCL] Fix use-after-free of the fast kernel subcache with SYCL_USE_KERNEL_SPV

### DIFF
--- a/sycl/source/detail/device_kernel_info.hpp
+++ b/sycl/source/detail/device_kernel_info.hpp
@@ -15,6 +15,7 @@
 #include <sycl/detail/ur.hpp>
 #include <sycl/kernel_bundle.hpp>
 
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string_view>
@@ -93,7 +94,9 @@ public:
   void init(std::string_view KernelName);
   void setCompileTimeInfoIfNeeded(const CompileTimeKernelInfoTy &Info);
 
-  FastKernelSubcacheT &getKernelSubcache() { return MFastKernelSubcache; }
+  const std::shared_ptr<FastKernelSubcacheT> &getKernelSubcache() {
+    return MFastKernelSubcache;
+  }
 
   const std::optional<int> &getImplicitLocalArgPos() const {
     return MImplicitLocalArgPos;
@@ -126,7 +129,13 @@ public:
 private:
   bool isCompileTimeInfoSet() const { return KernelSize != 0; }
 
-  FastKernelSubcacheT MFastKernelSubcache;
+  // Shared ownership is required: instances of KernelProgramCache keep a
+  // reference to this subcache (see FastKernelSubcacheWrapper) and may outlive
+  // this object. That happens when the device image owning this kernel name is
+  // unregistered (e.g. on dlclose, or on Windows when the module holding the
+  // kernel is unloaded) before the runtime shuts down and clears its caches.
+  std::shared_ptr<FastKernelSubcacheT> MFastKernelSubcache =
+      std::make_shared<FastKernelSubcacheT>();
   std::optional<int> MImplicitLocalArgPos;
   bool MWorkGroupDynamicLocalMem = false;
   const std::optional<sycl::kernel_id> MKernelID;

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -220,22 +220,24 @@ public:
       ur_program_handle_t,
       emhash8::HashMap<std::string_view, std::shared_ptr<KernelBuildResult>>>;
 
+  // Keeps shared ownership of a kernel's subcache. The subcache is owned by the
+  // corresponding DeviceKernelInfo, which can be destroyed before this cache is
+  // cleared (that happens when the device image owning the kernel name is
+  // unregistered while the runtime is still alive), hence the shared_ptr.
   class FastKernelSubcacheWrapper {
   public:
-    FastKernelSubcacheWrapper(FastKernelSubcacheT &Subcache,
+    FastKernelSubcacheWrapper(std::shared_ptr<FastKernelSubcacheT> Subcache,
                               ur_context_handle_t UrContext)
-        : MSubcachePtr{&Subcache}, MUrContext{UrContext} {}
+        : MSubcachePtr{std::move(Subcache)}, MUrContext{UrContext} {}
     FastKernelSubcacheWrapper(const FastKernelSubcacheWrapper &) = delete;
     FastKernelSubcacheWrapper(FastKernelSubcacheWrapper &&Other)
-        : MSubcachePtr{Other.MSubcachePtr}, MUrContext{Other.MUrContext} {
-      Other.MSubcachePtr = nullptr;
-    }
+        : MSubcachePtr{std::move(Other.MSubcachePtr)},
+          MUrContext{Other.MUrContext} {}
     FastKernelSubcacheWrapper &
     operator=(const FastKernelSubcacheWrapper &) = delete;
     FastKernelSubcacheWrapper &operator=(FastKernelSubcacheWrapper &&Other) {
-      MSubcachePtr = Other.MSubcachePtr;
+      MSubcachePtr = std::move(Other.MSubcachePtr);
       MUrContext = Other.MUrContext;
-      Other.MSubcachePtr = nullptr;
       return *this;
     };
 
@@ -258,7 +260,7 @@ public:
     FastKernelSubcacheT &get() { return *MSubcachePtr; }
 
   private:
-    FastKernelSubcacheT *MSubcachePtr = nullptr;
+    std::shared_ptr<FastKernelSubcacheT> MSubcachePtr;
     ur_context_handle_t MUrContext = nullptr;
   };
 
@@ -464,7 +466,7 @@ public:
 
   void saveKernel(std::string_view KernelName, ur_device_handle_t Device,
                   const FastKernelCacheValPtr &CacheVal,
-                  FastKernelSubcacheT &KernelSubcache) {
+                  const std::shared_ptr<FastKernelSubcacheT> &KernelSubcache) {
     if (SYCLConfig<SYCL_IN_MEM_CACHE_EVICTION_THRESHOLD>::
             isProgramCacheEvictionEnabled()) {
       // Save kernel in fast cache only if the corresponding program is also
@@ -488,10 +490,10 @@ public:
         std::string(KernelName),
         FastKernelSubcacheWrapper(KernelSubcache, getURContext()));
 
-    FastKernelSubcacheWriteLockT SubcacheLock{KernelSubcache.Mutex};
+    FastKernelSubcacheWriteLockT SubcacheLock{KernelSubcache->Mutex};
     ur_context_handle_t Context = getURContext();
-    KernelSubcache.Entries.emplace_back(FastKernelCacheKeyT(Device, Context),
-                                        CacheVal);
+    KernelSubcache->Entries.emplace_back(FastKernelCacheKeyT(Device, Context),
+                                         CacheVal);
   }
 
   // Expects locked program cache

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1098,7 +1098,7 @@ FastKernelCacheValPtr ProgramManager::getOrCreateKernel(
   if (SYCLConfig<SYCL_CACHE_IN_MEM>::get()) {
     if (auto KernelCacheValPtr =
             Cache.tryToGetKernelFast(DeviceKernelInfo.Name, UrDevice,
-                                     DeviceKernelInfo.getKernelSubcache())) {
+                                     *DeviceKernelInfo.getKernelSubcache())) {
       return KernelCacheValPtr;
     }
   }
@@ -1243,8 +1243,8 @@ ProgramManager::ProgramManager()
                           UseSpvEnv + ": " + SpvFile);
     File.seekg(0, std::ios::end);
     size_t Size = File.tellg();
-    std::unique_ptr<char[], std::function<void(void *)>> Data(new char[Size],
-                                                              std::free);
+    std::unique_ptr<char[], std::function<void(void *)>> Data(
+        new char[Size], [](void *Ptr) { delete[] static_cast<char *>(Ptr); });
     File.seekg(0);
     File.read(Data.get(), Size);
     File.close();
@@ -1762,7 +1762,8 @@ void ProgramManager::addImage(sycl_device_binary RawImg,
         size_t ImgSize =
             static_cast<size_t>(RawImg->BinaryEnd - RawImg->BinaryStart);
         std::unique_ptr<char[], std::function<void(void *)>> Data(
-            new char[ImgSize], std::free);
+            new char[ImgSize],
+            [](void *Ptr) { delete[] static_cast<char *>(Ptr); });
         std::memcpy(Data.get(), RawImg->BinaryStart, ImgSize);
         DevImg =
             std::make_unique<DynRTDeviceBinaryImage>(std::move(Data), ImgSize);


### PR DESCRIPTION
## The bug

A context's fast kernel cache stores `FastKernelSubcacheWrapper`s, each holding a **raw, non-owning** pointer to the `FastKernelSubcacheT` that lives inside the kernel's `DeviceKernelInfo`:

```cpp
// sycl/source/detail/kernel_program_cache.hpp
FastKernelSubcacheT *MSubcachePtr = nullptr;   // owned by DeviceKernelInfo
```

Nothing couples the two lifetimes. `ProgramManager::removeImages()` destroys the `DeviceKernelInfo` — and with it the subcache — as soon as the last image referencing that kernel name is unregistered (`program_manager.cpp:1979`), while the cache entry lives on. `~FastKernelSubcacheWrapper` then locks the subcache's `SpinLock` and mutates its `Entries` vector, i.e. writes to freed memory, when the cache is cleared.

For programs built from a registered image this is masked: `removeImages()` calls `removeAllRelatedEntries()` → `removeProgramByKey()`, which erases the matching fast-kernel-cache entries *before* the `DeviceKernelInfo` dies. That cleanup is keyed on `NativePrograms[Prog].second == Img`.

**With `SYCL_USE_KERNEL_SPV` every program is built from `m_SpvFileImage`** (`getDeviceImage()`, `program_manager.cpp:1379-1384`), a `DynRTDeviceBinaryImage` that never goes through `addImage()`/`m_DeviceImages`. So no unregistered image ever matches, the cleanup never runs, and the wrapper survives with a dangling pointer.

**Why it shows up on Windows:** the EXE's static destructors (`__sycl_unregister_lib` → `removeImages`) run *before* libsycl's `DllMain(DLL_PROCESS_DETACH)` → `shutdown_early()` → `KernelProgramCache::reset()`. On Linux the ordering is reversed (`StaticVarShutdownHandler` is constructed later than the app's registration object), so a plain run does not fault — a `dlclose` is needed to force the Windows ordering.

**Why reordering the `clear()` calls in `reset()` "fixes" it:** it doesn't, it hides it. Clearing `MFastKernelCache` first runs the wrapper destructors before the program/kernel teardown does thousands of allocations inside `urProgramRelease`/`urKernelRelease` and recycles that block, so the freed memory is still bit-intact and the erase is a silent no-op. Classic heap-reuse-dependent UAF.

## The fix

Give the subcache shared ownership, so `~FastKernelSubcacheWrapper` is correct regardless of destruction order. The per-submission hot path (`tryToGetKernelFast()`) keeps taking a plain `FastKernelSubcacheT &`, so **no reference counting is added to kernel submission** — the only added cost is one pointer load, plus one atomic increment per (kernel, context) in the cold `saveKernel()`.

Alternatives considered and rejected:
* *Stop erasing `m_DeviceKernelInfoMap` in `removeImages()`* (zero cost, one deleted line) — unsafe: `DeviceKernelInfo::Name` is a `string_view` into the unloaded module's offload-entry table (`program_manager.cpp:1832`), so a surviving entry has a dangling `Name` that a later re-`dlopen` compares in `setCompileTimeInfoIfNeeded()`.
* *Purge the fast cache from `removeImages()`* — requires enumerating every context's cache; only default contexts are enumerable, so user-created contexts would stay broken. Symptom-level anyway: `reset()` also clears `MCachedPrograms.Cache` without clearing its `KeyMap`, which makes a later `removeAllRelatedEntries()` bail out at `removeProgramByKey()`'s `Cache.find()` — the same dangling wrapper, reachable without `SYCL_USE_KERNEL_SPV`. Fixing the ownership covers both.

Also fixed on the same code path: both sites building a `DynRTDeviceBinaryImage` (the SPIR-V file loaded for `SYCL_USE_KERNEL_SPV`, and the copy made for an uncompressed image in `addImage()`) allocate with `new char[]` but passed `std::free` as the deleter, which ASan reports as `alloc-dealloc-mismatch (operator new [] vs free)` in `~DynRTDeviceBinaryImage()`.

## Reproducer

No test is added: on Linux the freed block is ordinary heap, so it only faults under a sanitizer, and the Windows-only manifestation is what actually crashes. Repro below, run against an ASan-instrumented `libsycl` (`-DLLVM_USE_SANITIZER=Address`).

`lib.cpp`:
```cpp
#include <sycl/detail/core.hpp>
#include <iostream>
extern "C" void run() {
  sycl::buffer<int> B(16);
  sycl::queue Q;
  Q.submit([&](sycl::handler &CGH) {
    sycl::accessor Acc{B, CGH};
    CGH.parallel_for(sycl::nd_range<1>{16, 16},
                     [=](sycl::nd_item<1> Id) { Acc[Id.get_global_id(0)] = 1; });
  });
  std::cout << "Result: " << sycl::host_accessor{B}[0] << std::endl;
}
```

`main.cpp` — the app keeps libsycl loaded, so the runtime's caches are cleared only at shutdown, after the library's image is unregistered (this is what Windows does on its own, without `dlclose`):
```cpp
#include <dlfcn.h>
#include <sycl/detail/core.hpp>
int main() {
  void *H = dlopen("./libkern.so", RTLD_NOW);
  ((void (*)())dlsym(H, "run"))();
  dlclose(H);
  return 0;
}
```

```sh
clang++ -fsycl -fno-sycl-dead-args-optimization -fno-sycl-instrument-device-code \
        -fPIC -shared lib.cpp -o libkern.so
clang++ -fsycl main.cpp -o main.out -ldl

# Dump the library's device image, then rerun with every program built from it.
SYCL_DUMP_IMAGES_PREFIX=./d_ SYCL_DUMP_IMAGES=1 ./main.out
SYCL_USE_KERNEL_SPV=./d_spir64.spv ./main.out
```

Before this change:

```
==1862069==ERROR: AddressSanitizer: heap-use-after-free on address 0x511000000498
WRITE of size 1 at 0x511000000498 thread T0
    #1 lock sycl/include/sycl/detail/spinlock.hpp:32:18
    #3 KernelProgramCache::FastKernelSubcacheWrapper::~FastKernelSubcacheWrapper()
       sycl/source/detail/kernel_program_cache.hpp:250:36
    #6 clear _deps/emhash-src/hash_table8.hpp:955:9
    #7 KernelProgramCache::reset()  sycl/source/detail/kernel_program_cache.hpp:700:22
    #8 shutdown_early(bool)         sycl/source/detail/global_handler.cpp:344:44
    #9 StaticVarShutdownHandler::~StaticVarShutdownHandler()
       sycl/source/detail/global_handler.cpp:251:7
freed by thread T0 here:
    #9 ProgramManager::removeImages(sycl_device_binaries_struct*)
       sycl/source/detail/program_manager/program_manager.cpp:1980:31
   #18 dlclose dlfcn/dlclose.c:31:10
```

After this change both that report and the `alloc-dealloc-mismatch` are gone, and the same binaries run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
